### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,4 +1,6 @@
 name: Scala CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SkatemapApp/skatemap-live/security/code-scanning/2](https://github.com/SkatemapApp/skatemap-live/security/code-scanning/2)

To fix the problem, you need to explicitly set the `permissions` key in your workflow or job to only allow the minimum required access. Since your workflow does not use the `GITHUB_TOKEN` for any write operations, the minimal permission required is `contents: read`. You should add a `permissions:` block at the root of your workflow YAML (just after the `name:` block) to apply to all jobs. This change should be made at the top of `.github/workflows/scala.yml`, no imports or additional code is needed elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
