### PR TITLE
chore: fix .gitignore and add VS Code team settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,10 @@ project/plugins/project/
 *.class
 *.log
 
+# Metals (Scala Language Server)
+.metals/
+.bloop/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/target": true
+    }
+}


### PR DESCRIPTION
## Summary
- Add missing `.metals/` and `.bloop/` directories to .gitignore
- Include VS Code team settings for better development experience

## Changes
- `.metals/` and `.bloop/` now properly ignored (Scala Metals LSP artifacts)
- Add `.vscode/settings.json` with target directory exclusion for improved performance
- Clean git status without irrelevant IDE artifacts

## Benefits
- Prevents Metals LSP artifacts from cluttering git status
- Shared VS Code settings improve team development experience
- Better performance by excluding build artifacts from file watching