### PR TITLE
chore: remove fake test coverage and unreachable defensive code

### DIFF
--- a/src/main/scala/skatemap/api/ValidationErrorAdapter.scala
+++ b/src/main/scala/skatemap/api/ValidationErrorAdapter.scala
@@ -15,12 +15,8 @@ object ValidationErrorAdapter {
         val detailsJson = Json.obj(
           details.map { case (key, value) =>
             val jsValue: Json.JsValueWrapper = value match {
-              case s: String  => s
-              case d: Double  => d
-              case i: Int     => i
-              case b: Boolean => b
-              case l: Long    => l
-              case _          => String.valueOf(value)
+              case s: String => s
+              case d: Double => d
             }
             key -> jsValue
           }.toSeq: _*

--- a/src/main/scala/skatemap/core/ValidationError.scala
+++ b/src/main/scala/skatemap/core/ValidationError.scala
@@ -60,18 +60,3 @@ final case class InvalidCoordinatesLengthError() extends ValidationError {
   val code    = "INVALID_COORDINATES_LENGTH"
   val message = "Coordinates array must contain exactly 2 numbers [longitude, latitude]"
 }
-
-final case class TestErrorWithMixedTypes() extends ValidationError {
-  val code    = "TEST_ERROR"
-  val message = "Test error with mixed types"
-  override val details: Option[Map[String, Any]] = Some(
-    Map(
-      "stringField" -> "test string",
-      "doubleField" -> 42.5,
-      "intField"    -> 123,
-      "boolField"   -> true,
-      "longField"   -> 999L,
-      "floatField"  -> 3.14f
-    )
-  )
-}

--- a/src/test/scala/skatemap/api/ValidationErrorAdapterSpec.scala
+++ b/src/test/scala/skatemap/api/ValidationErrorAdapterSpec.scala
@@ -23,23 +23,21 @@ class ValidationErrorAdapterSpec extends AnyWordSpec with Matchers {
     }
 
     "handle various types in details map" in {
-      val error  = TestErrorWithMixedTypes()
+      val error  = InvalidLongitudeError(200.0)
       val result = ValidationErrorAdapter.toJsonResponse(error)
 
       result.header.status shouldBe 400
 
       error.details should be(defined)
       val Some(details) = error.details
-      details should contain key "stringField"
-      details should contain key "doubleField"
-      details should contain key "intField"
-      details should contain key "boolField"
+      details should contain key "field"
+      details should contain key "value"
+      details should contain key "constraint"
 
-      details("stringField") shouldBe "test string"
-      details("doubleField") shouldBe 42.5
-      details("intField") shouldBe 123
-      details("boolField") shouldBe true
-      details("longField") shouldBe 999L
+      details("field") shouldBe "coordinates[0]"
+      details("value") shouldBe 200.0
+      details("constraint") shouldBe "range(-180.0, 180.0)"
     }
+
   }
 }


### PR DESCRIPTION
## Summary
- Removes `TestErrorWithMixedTypes` from production `ValidationError` sealed trait
- Removes unreachable fallback case in `ValidationErrorAdapter` 
- Results in honest test coverage that only tests real functionality

## Problem
`TestErrorWithMixedTypes` was added to production code solely to achieve 100% test coverage, which is coverage theater. Additionally, the fallback case in `ValidationErrorAdapter` was unreachable because `ValidationError` is a sealed trait that only allows String and Double types in details maps.

## Solution
Since `ValidationError` is sealed and we control all implementations, the pattern match in `ValidationErrorAdapter` is exhaustive with just String and Double cases. No defensive fallback needed.

## Test Plan
- [x] All tests pass with honest coverage
- [x] No fake test fixtures in production code
- [x] ValidationErrorAdapter only handles types actually used

🤖 Generated with [Claude Code](https://claude.ai/code)