### PR TITLE
feat: add automatic cleanup service for stale locations

### DIFF
--- a/src/main/scala/skatemap/core/CleanupService.scala
+++ b/src/main/scala/skatemap/core/CleanupService.scala
@@ -1,0 +1,25 @@
+package skatemap.core
+
+import org.apache.pekko.actor.ActorSystem
+import play.api.inject.ApplicationLifecycle
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+@Singleton
+class CleanupService @Inject() (
+  store: LocationStore,
+  actorSystem: ActorSystem,
+  lifecycle: ApplicationLifecycle,
+  ec: ExecutionContext
+) {
+  implicit val executionContext: ExecutionContext = ec
+
+  private val cancellable = actorSystem.scheduler.scheduleWithFixedDelay(
+    initialDelay = 10.seconds,
+    delay = 10.seconds
+  )(() => store.cleanupAll())
+
+  lifecycle.addStopHook(() => Future.successful(cancellable.cancel()))
+}

--- a/src/main/scala/skatemap/core/InMemoryLocationStore.scala
+++ b/src/main/scala/skatemap/core/InMemoryLocationStore.scala
@@ -33,4 +33,14 @@ class InMemoryLocationStore @Inject() (clock: Clock) extends LocationStore {
       if (eventMap.isEmpty) { store.remove(eventId) }
     }
   }
+
+  def cleanupAll(): Unit = {
+    val cutoff = clock.instant().minusSeconds(maxAge.toSeconds)
+
+    store.foreachEntry { case (eventId, eventMap) =>
+      eventMap.filterInPlace { case (_, (_, timestamp)) => timestamp.isAfter(cutoff) }
+
+      if (eventMap.isEmpty) { store.remove(eventId) }
+    }
+  }
 }

--- a/src/main/scala/skatemap/core/LocationStore.scala
+++ b/src/main/scala/skatemap/core/LocationStore.scala
@@ -6,4 +6,5 @@ trait LocationStore {
   def put(eventId: String, location: Location): Unit
   def getAll(eventId: String): Map[String, Location]
   def cleanup(): Unit
+  def cleanupAll(): Unit
 }

--- a/src/main/scala/skatemap/infra/SkatemapLiveModule.scala
+++ b/src/main/scala/skatemap/infra/SkatemapLiveModule.scala
@@ -1,7 +1,14 @@
 package skatemap.infra
 
 import com.google.inject.{AbstractModule, Provides}
-import skatemap.core.{Broadcaster, InMemoryBroadcaster, InMemoryLocationStore, LocationStore, StreamConfig}
+import skatemap.core.{
+  Broadcaster,
+  CleanupService,
+  InMemoryBroadcaster,
+  InMemoryLocationStore,
+  LocationStore,
+  StreamConfig
+}
 
 import java.time.Clock
 import javax.inject.Singleton
@@ -10,6 +17,7 @@ class SkatemapLiveModule extends AbstractModule {
   override def configure(): Unit = {
     bind(classOf[LocationStore]).to(classOf[InMemoryLocationStore])
     bind(classOf[Broadcaster]).to(classOf[InMemoryBroadcaster])
+    bind(classOf[CleanupService]).asEagerSingleton()
   }
 
   @Provides

--- a/src/test/scala/skatemap/api/LocationControllerSpec.scala
+++ b/src/test/scala/skatemap/api/LocationControllerSpec.scala
@@ -33,6 +33,8 @@ class LocationControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injec
       Option(storage.get(eventId)).getOrElse(Map.empty)
 
     def cleanup(): Unit = storage.clear()
+
+    def cleanupAll(): Unit = storage.clear()
   }
 
   private class MockBroadcaster extends Broadcaster {

--- a/src/test/scala/skatemap/api/StreamControllerSpec.scala
+++ b/src/test/scala/skatemap/api/StreamControllerSpec.scala
@@ -15,6 +15,7 @@ class StreamControllerSpec extends AnyWordSpec with Matchers {
     def put(eventId: String, location: Location): Unit = ()
     def getAll(eventId: String): Map[String, Location] = Map.empty
     def cleanup(): Unit                                = ()
+    def cleanupAll(): Unit                             = ()
   }
 
   private class MockBroadcaster extends Broadcaster {

--- a/src/test/scala/skatemap/core/CleanupServiceSpec.scala
+++ b/src/test/scala/skatemap/core/CleanupServiceSpec.scala
@@ -1,0 +1,57 @@
+package skatemap.core
+
+import org.apache.pekko.actor.ActorSystem
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Second, Seconds, Span}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+class CleanupServiceSpec extends AnyWordSpec with Matchers with Eventually with MockitoSugar {
+
+  "CleanupService" should {
+
+    "register shutdown hook with ApplicationLifecycle" in {
+      val mockStore     = mock[LocationStore]
+      val mockLifecycle = mock[ApplicationLifecycle]
+      val actorSystem   = ActorSystem("test")
+
+      doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
+
+      try {
+        new CleanupService(mockStore, actorSystem, mockLifecycle, actorSystem.dispatcher)
+
+        verify(mockLifecycle).addStopHook(any[() => Future[_]])
+      } finally {
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, 5.seconds)
+      }
+    }
+
+    "schedule cleanup to run every 10 seconds" in {
+      val mockStore     = mock[LocationStore]
+      val mockLifecycle = mock[ApplicationLifecycle]
+      val actorSystem   = ActorSystem("test")
+
+      doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
+
+      try {
+        new CleanupService(mockStore, actorSystem, mockLifecycle, actorSystem.dispatcher)
+
+        eventually(timeout(Span(12, Seconds)), interval(Span(1, Second))) {
+          verify(mockStore, atLeastOnce()).cleanupAll()
+        }
+      } finally {
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, 5.seconds)
+      }
+    }
+
+  }
+}

--- a/src/test/scala/skatemap/core/EventStreamServiceSpec.scala
+++ b/src/test/scala/skatemap/core/EventStreamServiceSpec.scala
@@ -47,6 +47,8 @@ class EventStreamServiceSpec
       Option(storage.get(eventId)).getOrElse(Map.empty)
 
     def cleanup(): Unit = storage.clear()
+
+    def cleanupAll(): Unit = storage.clear()
   }
 
   private class MockBroadcaster extends Broadcaster {

--- a/src/test/scala/skatemap/core/LocationStoreSpec.scala
+++ b/src/test/scala/skatemap/core/LocationStoreSpec.scala
@@ -90,5 +90,28 @@ class LocationStoreSpec extends AnyWordSpec with Matchers {
       remaining shouldBe empty
     }
 
+    "cleanupAll should remove stale locations from all events" in {
+      val store           = new InMemoryLocationStore(fixedClock)
+      val event1          = "event-1"
+      val event2          = "event-2"
+      val oldTimestamp    = 10000L
+      val recentTimestamp = 40000L
+
+      val oldLocation    = Location("skater-old", 45.0, -122.0, oldTimestamp)
+      val recentLocation = Location("skater-recent", 46.0, -123.0, recentTimestamp)
+
+      store.put(event1, oldLocation)
+      store.put(event1, recentLocation)
+      store.put(event2, oldLocation)
+
+      store.cleanupAll()
+
+      val event1Remaining = store.getAll(event1)
+      val event2Remaining = store.getAll(event2)
+
+      event1Remaining should contain only ("skater-recent" -> recentLocation)
+      event2Remaining shouldBe empty
+    }
+
   }
 }


### PR DESCRIPTION
## Summary
- Implement CleanupService using Akka Scheduler to automatically remove stale locations
- Service runs every 10 seconds, cleaning locations older than 30 seconds from all events
- Proper lifecycle integration for clean shutdown when application stops

## Changes
- Add `CleanupService` with Akka scheduler (10s interval)
- Add `cleanupAll()` method to `LocationStore` trait
- Implement `cleanupAll()` in `InMemoryLocationStore`
- Bind `CleanupService` as eager singleton in `SkatemapLiveModule`
- Add lifecycle integration with `ApplicationLifecycle` for clean shutdown
- Add tests verifying automatic cleanup and lifecycle hooks
- Update mock `LocationStore` implementations in tests

## Test plan
- CleanupService registers shutdown hook with ApplicationLifecycle
- Cleanup runs automatically every 10 seconds
- cleanupAll() removes stale locations from all events
- Empty events removed from memory

Closes https://github.com/SkatemapApp/skatemap-live/issues/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)