### PR TITLE
feat: add health check endpoint

### DIFF
--- a/src/main/resources/routes
+++ b/src/main/resources/routes
@@ -1,2 +1,3 @@
+GET     /health                                             skatemap.api.HealthController.health
 PUT     /skatingEvents/:skatingEventId/skaters/:skaterId    skatemap.api.LocationController.updateLocation(skatingEventId, skaterId)
 GET     /skatingEvents/:eventId/stream                      skatemap.api.StreamController.streamEvent(eventId)

--- a/src/main/scala/skatemap/api/HealthController.scala
+++ b/src/main/scala/skatemap/api/HealthController.scala
@@ -1,0 +1,15 @@
+package skatemap.api
+
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class HealthController @Inject() (
+  val controllerComponents: ControllerComponents
+) extends BaseController {
+
+  def health: Action[AnyContent] = Action {
+    Ok
+  }
+}

--- a/src/test/scala/skatemap/api/HealthControllerIntegrationSpec.scala
+++ b/src/test/scala/skatemap/api/HealthControllerIntegrationSpec.scala
@@ -1,0 +1,29 @@
+package skatemap.api
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice._
+import play.api.http.Status.OK
+import play.api.test.Helpers._
+import play.api.test._
+
+class HealthControllerIntegrationSpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
+
+  "Health check endpoint" should {
+
+    "return OK status" in {
+      val request = FakeRequest(GET, "/health")
+
+      val result = route(app, request).fold(fail("Route not found"))(identity)
+
+      status(result) mustBe OK
+    }
+
+    "return empty response body" in {
+      val request = FakeRequest(GET, "/health")
+
+      val result = route(app, request).fold(fail("Route not found"))(identity)
+
+      contentAsString(result) mustBe ""
+    }
+  }
+}

--- a/src/test/scala/skatemap/api/HealthControllerSpec.scala
+++ b/src/test/scala/skatemap/api/HealthControllerSpec.scala
@@ -1,0 +1,43 @@
+package skatemap.api
+
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice._
+import play.api.http.Status.OK
+import play.api.test.Helpers._
+import play.api.test._
+
+class HealthControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
+
+  private def createController() = new skatemap.api.HealthController(
+    stubControllerComponents()
+  )
+
+  "HealthController.health" should {
+
+    "return OK status" in {
+      val controller = createController()
+      val request    = FakeRequest(GET, "/health")
+
+      val result = controller.health.apply(request)
+
+      status(result) mustBe OK
+    }
+
+    "return empty response body" in {
+      val controller = createController()
+      val request    = FakeRequest(GET, "/health")
+
+      val result = controller.health.apply(request)
+
+      contentAsString(result) mustBe ""
+    }
+
+    "handle requests through routing" in {
+      val request = FakeRequest(GET, "/health")
+
+      val result = route(app, request).fold(fail("Route not found"))(identity)
+
+      status(result) mustBe OK
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add GET /health endpoint for monitoring service availability
- Returns 200 OK with empty response body
- No authentication required
- No external dependencies

## Test Plan
- Unit tests verify controller logic
- Integration tests verify routing

## Closes
Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)