### PR TITLE
feat: add HTML viewer for event-based WebSocket streaming

### DIFF
--- a/src/main/resources/public/viewer.html
+++ b/src/main/resources/public/viewer.html
@@ -1,0 +1,425 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skatemap Live - Event Viewer</title>
+<style>
+    * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
+
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        background: #f5f5f5;
+        padding: 20px;
+        color: #333;
+    }
+
+    .container {
+        max-width: 1200px;
+        margin: 0 auto;
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        padding: 24px;
+    }
+
+    header {
+        margin-bottom: 24px;
+        padding-bottom: 16px;
+        border-bottom: 2px solid #e0e0e0;
+    }
+
+    h1 {
+        font-size: 28px;
+        color: #2c3e50;
+        margin-bottom: 8px;
+    }
+
+    .subtitle {
+        color: #7f8c8d;
+        font-size: 14px;
+    }
+
+    .controls {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 20px;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
+    input[type="text"] {
+        flex: 1;
+        min-width: 200px;
+        padding: 10px 14px;
+        border: 2px solid #e0e0e0;
+        border-radius: 6px;
+        font-size: 14px;
+        transition: border-color 0.2s;
+    }
+
+    input[type="text"]:focus {
+        outline: none;
+        border-color: #3498db;
+    }
+
+    button {
+        padding: 10px 20px;
+        border: none;
+        border-radius: 6px;
+        font-size: 14px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .btn-connect {
+        background: #3498db;
+        color: white;
+    }
+
+    .btn-connect:hover:not(:disabled) {
+        background: #2980b9;
+    }
+
+    .btn-disconnect {
+        background: #e74c3c;
+        color: white;
+    }
+
+    .btn-disconnect:hover:not(:disabled) {
+        background: #c0392b;
+    }
+
+    .status-bar {
+        padding: 12px 16px;
+        border-radius: 6px;
+        margin-bottom: 20px;
+        font-size: 14px;
+        font-weight: 500;
+    }
+
+    .status-disconnected {
+        background: #ecf0f1;
+        color: #7f8c8d;
+    }
+
+    .status-connected {
+        background: #d4edda;
+        color: #155724;
+        border: 1px solid #c3e6cb;
+    }
+
+    .status-error {
+        background: #f8d7da;
+        color: #721c24;
+        border: 1px solid #f5c6cb;
+    }
+
+    .locations-container {
+        margin-top: 20px;
+    }
+
+    .section-title {
+        font-size: 18px;
+        font-weight: 600;
+        margin-bottom: 12px;
+        color: #2c3e50;
+    }
+
+    .empty-state {
+        text-align: center;
+        padding: 40px;
+        color: #95a5a6;
+        font-size: 14px;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+    }
+
+    thead {
+        background: #f8f9fa;
+    }
+
+    th {
+        text-align: left;
+        padding: 12px;
+        font-weight: 600;
+        color: #495057;
+        border-bottom: 2px solid #dee2e6;
+    }
+
+    td {
+        padding: 12px;
+        border-bottom: 1px solid #e9ecef;
+    }
+
+    tbody tr:hover {
+        background: #f8f9fa;
+    }
+
+    .skater-id {
+        font-weight: 600;
+        color: #2c3e50;
+    }
+
+    .coord {
+        font-family: 'Courier New', monospace;
+        color: #5a6c7d;
+    }
+
+    .timestamp {
+        color: #7f8c8d;
+        font-size: 13px;
+    }
+
+    .stats {
+        display: flex;
+        gap: 20px;
+        margin-bottom: 16px;
+        font-size: 13px;
+        color: #7f8c8d;
+    }
+
+    .stat-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .stat-value {
+        font-weight: 600;
+        color: #2c3e50;
+    }
+</style>
+</head>
+<body>
+<div class="container">
+    <header>
+        <h1>🛹 Skatemap Live</h1>
+        <p class="subtitle">Real-time location streaming viewer</p>
+    </header>
+
+    <div class="controls">
+        <input
+            type="text"
+            id="eventIdInput"
+            placeholder="Enter event ID (e.g., event-123)"
+            autocomplete="off"
+        >
+        <button id="connectBtn" class="btn-connect">Connect</button>
+        <button id="disconnectBtn" class="btn-disconnect" disabled>Disconnect</button>
+    </div>
+
+    <div id="statusBar" class="status-bar status-disconnected">
+        Disconnected
+    </div>
+
+    <div class="locations-container">
+        <div class="section-title">Active Skaters</div>
+        <div class="stats">
+            <div class="stat-item">
+                <span>Event:</span>
+                <span class="stat-value" id="currentEvent">None</span>
+            </div>
+            <div class="stat-item">
+                <span>Skaters:</span>
+                <span class="stat-value" id="skaterCount">0</span>
+            </div>
+            <div class="stat-item">
+                <span>Last update:</span>
+                <span class="stat-value" id="lastUpdate">Never</span>
+            </div>
+        </div>
+
+        <div id="emptyState" class="empty-state">
+            Connect to an event to view skater locations
+        </div>
+
+        <table id="locationsTable" style="display: none;">
+            <thead>
+                <tr>
+                    <th>Skater ID</th>
+                    <th>Latitude</th>
+                    <th>Longitude</th>
+                    <th>Last Update</th>
+                </tr>
+            </thead>
+            <tbody id="locationsBody">
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script>
+    let ws = null;
+    let currentEventId = null;
+    const skaterLocations = new Map();
+
+    const elements = {
+        eventIdInput: document.getElementById('eventIdInput'),
+        connectBtn: document.getElementById('connectBtn'),
+        disconnectBtn: document.getElementById('disconnectBtn'),
+        statusBar: document.getElementById('statusBar'),
+        emptyState: document.getElementById('emptyState'),
+        locationsTable: document.getElementById('locationsTable'),
+        locationsBody: document.getElementById('locationsBody'),
+        currentEvent: document.getElementById('currentEvent'),
+        skaterCount: document.getElementById('skaterCount'),
+        lastUpdate: document.getElementById('lastUpdate')
+    };
+
+    function setStatus(message, type) {
+        elements.statusBar.textContent = message;
+        elements.statusBar.className = `status-bar status-${type}`;
+    }
+
+    function updateStats() {
+        elements.currentEvent.textContent = currentEventId || 'None';
+        elements.skaterCount.textContent = skaterLocations.size;
+
+        if (skaterLocations.size > 0) {
+            elements.emptyState.style.display = 'none';
+            elements.locationsTable.style.display = 'table';
+        } else {
+            elements.emptyState.style.display = 'block';
+            elements.locationsTable.style.display = 'none';
+            elements.emptyState.textContent = currentEventId
+                ? 'No active skaters in this event'
+                : 'Connect to an event to view skater locations';
+        }
+    }
+
+    function formatTimestamp(isoString) {
+        const date = new Date(isoString);
+        return date.toLocaleTimeString('en-US', {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit'
+        });
+    }
+
+    function formatCoordinate(coord) {
+        return coord.toFixed(6);
+    }
+
+    function updateLocationDisplay(batch) {
+        if (!batch || !batch.locations || !Array.isArray(batch.locations) || batch.locations.length === 0) {
+            return;
+        }
+
+        batch.locations.forEach(location => {
+            skaterLocations.set(location.skaterId, location);
+        });
+
+        elements.lastUpdate.textContent = formatTimestamp(new Date().toISOString());
+
+        elements.locationsBody.innerHTML = '';
+
+        const sortedEntries = Array.from(skaterLocations.entries())
+            .sort((a, b) => a[0].localeCompare(b[0]));
+
+        sortedEntries.forEach(([skaterId, location]) => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td class="skater-id">${skaterId}</td>
+                <td class="coord">${formatCoordinate(location.latitude)}</td>
+                <td class="coord">${formatCoordinate(location.longitude)}</td>
+                <td class="timestamp">${formatTimestamp(location.timestamp)}</td>
+            `;
+            elements.locationsBody.appendChild(row);
+        });
+
+        updateStats();
+    }
+
+    function connectToEvent(eventId) {
+        if (!eventId.trim()) {
+            setStatus('Please enter an event ID', 'error');
+            return;
+        }
+
+        if (ws) {
+            ws.close();
+        }
+
+        skaterLocations.clear();
+        currentEventId = eventId.trim();
+
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsUrl = `${protocol}//${window.location.host}/skatingEvents/${currentEventId}/stream`;
+
+        setStatus(`Connecting to event: ${currentEventId}...`, 'disconnected');
+
+        ws = new WebSocket(wsUrl);
+
+        ws.onopen = () => {
+            setStatus(`Connected to event: ${currentEventId}`, 'connected');
+            elements.connectBtn.disabled = true;
+            elements.disconnectBtn.disabled = false;
+            elements.eventIdInput.disabled = true;
+            updateStats();
+        };
+
+        ws.onmessage = (event) => {
+            try {
+                const data = JSON.parse(event.data);
+                updateLocationDisplay(data);
+            } catch (e) {
+                console.error('Failed to parse WebSocket message:', e);
+            }
+        };
+
+        ws.onerror = () => {
+            setStatus('Connection error', 'error');
+        };
+
+        ws.onclose = () => {
+            setStatus('Disconnected', 'disconnected');
+            elements.connectBtn.disabled = false;
+            elements.disconnectBtn.disabled = true;
+            elements.eventIdInput.disabled = false;
+            ws = null;
+            currentEventId = null;
+            skaterLocations.clear();
+            updateStats();
+        };
+    }
+
+    function disconnect() {
+        if (ws) {
+            ws.close();
+        }
+    }
+
+    elements.connectBtn.addEventListener('click', () => {
+        const eventId = elements.eventIdInput.value;
+        connectToEvent(eventId);
+    });
+
+    elements.disconnectBtn.addEventListener('click', () => {
+        disconnect();
+    });
+
+    elements.eventIdInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter' && !elements.connectBtn.disabled) {
+            connectToEvent(elements.eventIdInput.value);
+        }
+    });
+
+    updateStats();
+</script>
+</body>
+</html>

--- a/src/main/resources/routes
+++ b/src/main/resources/routes
@@ -1,3 +1,4 @@
 GET     /health                                             skatemap.api.HealthController.health
 PUT     /skatingEvents/:skatingEventId/skaters/:skaterId    skatemap.api.LocationController.updateLocation(skatingEventId, skaterId)
 GET     /skatingEvents/:eventId/stream                      skatemap.api.StreamController.streamEvent(eventId)
+GET     /assets/*file                                       controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
## Summary
- Add HTML viewer for real-time WebSocket location streaming
- Add assets route to serve static files from public directory
- Fix JavaScript to handle LocationBatch JSON format

## Implementation Details
- Created `src/main/resources/public/viewer.html` with event connection UI
- Updated routes to serve assets from `/public` directory
- WebSocket connects to `/skatingEvents/:eventId/stream`
- Displays real-time location updates with skaterId, latitude, longitude, timestamp
- Handles connection states and event isolation

## Testing
Manual testing confirmed:
- HTML loads at http://localhost:9000/assets/viewer.html
- WebSocket connection establishes successfully
- Real-time location updates display correctly
- Event isolation verified with multiple browser tabs

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)