### PR TITLE
feat: return JSON for HTTP error responses

### DIFF
--- a/src/test/scala/skatemap/api/ErrorHandlerIntegrationSpec.scala
+++ b/src/test/scala/skatemap/api/ErrorHandlerIntegrationSpec.scala
@@ -16,5 +16,21 @@ class ErrorHandlerIntegrationSpec extends PlaySpec with GuiceOneAppPerTest with 
       status(result) mustBe NOT_FOUND
       contentType(result) mustBe Some("application/json")
     }
+
+    "return properly structured error messages" in {
+      val request = FakeRequest(GET, "/nonexistent-endpoint")
+      val result  = route(app, request).fold(fail("Route not found"))(identity)
+
+      status(result) mustBe NOT_FOUND
+      contentType(result) mustBe Some("application/json")
+
+      val json      = contentAsJson(result)
+      val error     = (json \ "error").get
+      val requestId = (error \ "requestId").asOpt[Int]
+      val message   = (error \ "message").asOpt[String]
+
+      requestId.isDefined mustBe true
+      message.isDefined mustBe true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Implements JSON error responses for HTTP errors instead of HTML
- Adds custom error handler that returns structured JSON error responses
- Closes #85

## Test plan
- Verify error responses return JSON format with appropriate status codes
- Check that error handler is properly registered in the application

🤖 Generated with [Claude Code](https://claude.com/claude-code)