### PR TITLE
feat: make location TTL configurable

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -7,4 +7,7 @@ skatemap {
     initialDelaySeconds = 10
     intervalSeconds = 10
   }
+  location {
+    ttlSeconds = 30
+  }
 }

--- a/src/main/scala/skatemap/core/InMemoryLocationStore.scala
+++ b/src/main/scala/skatemap/core/InMemoryLocationStore.scala
@@ -5,12 +5,11 @@ import skatemap.domain.Location
 import java.time.{Clock, Instant}
 import javax.inject.{Inject, Singleton}
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.duration._
 
 @Singleton
-class InMemoryLocationStore @Inject() (clock: Clock) extends LocationStore {
+class InMemoryLocationStore @Inject() (clock: Clock, config: LocationConfig) extends LocationStore {
   private val store: TrieMap[String, TrieMap[String, (Location, Instant)]] = TrieMap.empty
-  private val maxAge                                                       = 30.seconds
+  private val maxAge                                                       = config.ttl
 
   def put(eventId: String, location: Location): Unit = {
     val eventMap  = store.getOrElseUpdate(eventId, TrieMap.empty)

--- a/src/main/scala/skatemap/core/LocationConfig.scala
+++ b/src/main/scala/skatemap/core/LocationConfig.scala
@@ -1,0 +1,9 @@
+package skatemap.core
+
+import scala.concurrent.duration._
+
+final case class LocationConfig(
+  ttl: FiniteDuration
+) {
+  require(ttl.toMillis > 0, "ttl must be positive")
+}

--- a/src/main/scala/skatemap/infra/SkatemapLiveModule.scala
+++ b/src/main/scala/skatemap/infra/SkatemapLiveModule.scala
@@ -8,6 +8,7 @@ import skatemap.core.{
   CleanupService,
   InMemoryBroadcaster,
   InMemoryLocationStore,
+  LocationConfig,
   LocationStore,
   StreamConfig
 }
@@ -50,6 +51,27 @@ class SkatemapLiveModule extends AbstractModule {
     CleanupConfig(
       initialDelay = getPositiveInt("skatemap.cleanup.initialDelaySeconds").seconds,
       interval = getPositiveInt("skatemap.cleanup.intervalSeconds").seconds
+    )
+  }
+
+  @Provides
+  @Singleton
+  def provideLocationConfig(config: Config): LocationConfig = {
+    def getPositiveInt(path: String): Int = {
+      require(
+        config.hasPath(path),
+        s"Required configuration missing: $path. Add it to application.conf"
+      )
+      val value = config.getInt(path)
+      require(
+        value > 0,
+        s"Invalid configuration: $path=${value.toString} (must be positive)"
+      )
+      value
+    }
+
+    LocationConfig(
+      ttl = getPositiveInt("skatemap.location.ttlSeconds").seconds
     )
   }
 }

--- a/src/test/scala/skatemap/core/LocationConfigSpec.scala
+++ b/src/test/scala/skatemap/core/LocationConfigSpec.scala
@@ -1,0 +1,33 @@
+package skatemap.core
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration._
+
+class LocationConfigSpec extends AnyWordSpec with Matchers {
+
+  "LocationConfig validation" should {
+
+    "reject zero ttl" in {
+      val exception = intercept[IllegalArgumentException] {
+        LocationConfig(ttl = 0.seconds)
+      }
+      exception.getMessage should include("ttl must be positive")
+    }
+
+    "reject negative ttl" in {
+      val exception = intercept[IllegalArgumentException] {
+        LocationConfig(ttl = (-1).seconds)
+      }
+      exception.getMessage should include("ttl must be positive")
+    }
+
+    "accept positive values" in {
+      val config = LocationConfig(ttl = 30.seconds)
+      config.ttl shouldBe 30.seconds
+    }
+
+  }
+
+}

--- a/src/test/scala/skatemap/infra/SkatemapLiveModuleSpec.scala
+++ b/src/test/scala/skatemap/infra/SkatemapLiveModuleSpec.scala
@@ -8,6 +8,59 @@ import scala.concurrent.duration._
 
 class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
 
+  "SkatemapLiveModule.provideLocationConfig" should {
+
+    "fail when ttlSeconds config path is missing" in {
+      val config = ConfigFactory.empty()
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideLocationConfig(config)
+      }
+      exception.getMessage should include("Required configuration missing: skatemap.location.ttlSeconds")
+    }
+
+    "fail when ttlSeconds is zero" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.location.ttlSeconds = 0
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideLocationConfig(config)
+      }
+      exception.getMessage should include(
+        "Invalid configuration: skatemap.location.ttlSeconds=0 (must be positive)"
+      )
+    }
+
+    "fail when ttlSeconds is negative" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.location.ttlSeconds = -30
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideLocationConfig(config)
+      }
+      exception.getMessage should include(
+        "Invalid configuration: skatemap.location.ttlSeconds=-30 (must be positive)"
+      )
+    }
+
+    "use configured value when present and positive" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.location.ttlSeconds = 45
+      """)
+      val module = new SkatemapLiveModule
+
+      val locationConfig = module.provideLocationConfig(config)
+
+      locationConfig.ttl shouldBe 45.seconds
+    }
+
+  }
+
   "SkatemapLiveModule.provideCleanupConfig" should {
 
     "fail when initialDelaySeconds config path is missing" in {


### PR DESCRIPTION
## Summary

Makes the location TTL configurable via `application.conf` instead of being hardcoded at 30 seconds.

- Created `LocationConfig` case class with TTL field and validation
- Updated `InMemoryLocationStore` to accept `LocationConfig` via constructor injection
- Added `provideLocationConfig` to `SkatemapLiveModule` with strict validation
- Added `skatemap.location.ttlSeconds = 30` to `application.conf`
- Added `LocationConfigSpec` with validation tests
- Added config validation tests to `SkatemapLiveModuleSpec`
- Updated `LocationStoreSpec` to inject config in tests
- Updated README with configuration documentation

## Configuration

```hocon
skatemap {
  location {
    ttlSeconds = 30
  }
}
```

## Test plan

- [x] All existing tests pass
- [x] New validation tests for `LocationConfig`
- [x] New validation tests for `provideLocationConfig`
- [x] Updated integration tests to use injected config

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)