### PR TITLE
feat: implement improvements from issue #67

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,16 @@ All configuration is in `application.conf` under the `skatemap` section:
 - Higher `batchIntervalMillis`: Batches fill before sending, better for high-volume events
 - Lower `batchIntervalMillis`: Messages sent more frequently, better for low-activity events
 
+### Hub Configuration
+- `skatemap.hub.ttlSeconds`: Time-to-live for unused broadcast hubs (must be positive integer)
+- `skatemap.hub.cleanupIntervalSeconds`: Interval between hub cleanup runs (must be positive integer)
+
+**Design Rationale:**
+- Default TTL: 300 seconds (5 minutes) - Balances memory usage with connection patterns
+- Default cleanup interval: 60 seconds (1 minute) - Provides regular cleanup without excessive overhead
+- Cleanup interval should be less than TTL to ensure timely removal of unused hubs
+- Hubs are created lazily and removed when not accessed (published to or subscribed) within TTL
+
 All values are validated at startup. Missing or non-positive values cause startup failure.
 
 ## Environment Variables

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -23,5 +23,10 @@ skatemap {
     # How often the cleanup process runs to remove unused hubs
     # Should be less than ttlSeconds to ensure timely cleanup
     cleanupIntervalSeconds = 60
+
+    # Buffer size for WebSocket broadcast hubs
+    # Number of messages to buffer per hub
+    # Higher values provide more resilience to slow consumers but use more memory
+    bufferSize = 128
   }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,4 +14,14 @@ skatemap {
     batchSize = 100
     batchIntervalMillis = 500
   }
+  hub {
+    # Time-to-live for unused broadcast hubs (5 minutes)
+    # Hubs that have not been accessed (published to or subscribed) for this duration will be removed
+    ttlSeconds = 300
+
+    # Cleanup interval (1 minute)
+    # How often the cleanup process runs to remove unused hubs
+    # Should be less than ttlSeconds to ensure timely cleanup
+    cleanupIntervalSeconds = 60
+  }
 }

--- a/src/main/scala/skatemap/core/BroadcasterCleanupService.scala
+++ b/src/main/scala/skatemap/core/BroadcasterCleanupService.scala
@@ -1,0 +1,46 @@
+package skatemap.core
+
+import org.apache.pekko.actor.ActorSystem
+import play.api.inject.ApplicationLifecycle
+import play.api.Logger
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+@Singleton
+class BroadcasterCleanupService @Inject() (
+  broadcaster: InMemoryBroadcaster,
+  config: HubConfig,
+  actorSystem: ActorSystem,
+  lifecycle: ApplicationLifecycle,
+  ec: ExecutionContext
+) {
+  implicit val executionContext: ExecutionContext = ec
+
+  private val logger = Logger(this.getClass)
+
+  logger.info(
+    s"BroadcasterCleanupService initialised with ttl=${config.ttl.toString()}, " +
+      s"cleanupInterval=${config.cleanupInterval.toString()}"
+  )
+
+  private val cancellable = actorSystem.scheduler.scheduleWithFixedDelay(
+    initialDelay = config.cleanupInterval,
+    delay = config.cleanupInterval
+  ) { () =>
+    scala.util.Try(broadcaster.cleanupUnusedHubs(config.ttl.toMillis)) match {
+      case Success(count) =>
+        if (count > 0) {
+          logger.info(s"Hub cleanup completed: removed ${count.toString()} hubs")
+        }
+      case Failure(error) =>
+        logger.error(s"Hub cleanup failed: ${error.getMessage}", error)
+    }
+  }
+
+  lifecycle.addStopHook { () =>
+    logger.info("Stopping BroadcasterCleanupService")
+    Future.successful(cancellable.cancel())
+  }
+}

--- a/src/main/scala/skatemap/core/HubConfig.scala
+++ b/src/main/scala/skatemap/core/HubConfig.scala
@@ -1,0 +1,8 @@
+package skatemap.core
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class HubConfig(
+  ttl: FiniteDuration,
+  cleanupInterval: FiniteDuration
+)

--- a/src/main/scala/skatemap/core/HubConfig.scala
+++ b/src/main/scala/skatemap/core/HubConfig.scala
@@ -4,5 +4,6 @@ import scala.concurrent.duration.FiniteDuration
 
 final case class HubConfig(
   ttl: FiniteDuration,
-  cleanupInterval: FiniteDuration
+  cleanupInterval: FiniteDuration,
+  bufferSize: Int
 )

--- a/src/main/scala/skatemap/core/InMemoryBroadcaster.scala
+++ b/src/main/scala/skatemap/core/InMemoryBroadcaster.scala
@@ -11,7 +11,7 @@ import javax.inject.{Inject, Singleton}
 import scala.collection.concurrent.TrieMap
 
 @Singleton
-class InMemoryBroadcaster @Inject() (system: ActorSystem, clock: Clock) extends Broadcaster {
+class InMemoryBroadcaster @Inject() (system: ActorSystem, clock: Clock, config: HubConfig) extends Broadcaster {
 
   implicit private val actorSystem: ActorSystem = system
 
@@ -28,7 +28,7 @@ class InMemoryBroadcaster @Inject() (system: ActorSystem, clock: Clock) extends 
       eventId, {
         val (sink, source) = MergeHub
           .source[Location]
-          .toMat(BroadcastHub.sink[Location](bufferSize = 128))(Keep.both)
+          .toMat(BroadcastHub.sink[Location](bufferSize = config.bufferSize))(Keep.both)
           .run()
         HubData(sink, source, new AtomicLong(clock.millis()))
       }

--- a/src/main/scala/skatemap/core/InMemoryBroadcaster.scala
+++ b/src/main/scala/skatemap/core/InMemoryBroadcaster.scala
@@ -5,32 +5,53 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.{BroadcastHub, Keep, MergeHub, Sink, Source}
 import skatemap.domain.Location
 
+import java.time.Clock
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.{Inject, Singleton}
 import scala.collection.concurrent.TrieMap
 
 @Singleton
-class InMemoryBroadcaster @Inject() (system: ActorSystem) extends Broadcaster {
+class InMemoryBroadcaster @Inject() (system: ActorSystem, clock: Clock) extends Broadcaster {
 
   implicit private val actorSystem: ActorSystem = system
 
-  private[core] val hubs = TrieMap[String, (Sink[Location, NotUsed], Source[Location, NotUsed])]()
+  private[core] case class HubData(
+    sink: Sink[Location, NotUsed],
+    source: Source[Location, NotUsed],
+    lastAccessed: AtomicLong
+  )
 
-  private def getOrCreateHub(eventId: String): (Sink[Location, NotUsed], Source[Location, NotUsed]) =
-    hubs.getOrElseUpdate(
-      eventId,
-      MergeHub
-        .source[Location]
-        .toMat(BroadcastHub.sink[Location](bufferSize = 128))(Keep.both)
-        .run()
+  private[core] val hubs = TrieMap[String, HubData]()
+
+  private def getOrCreateHub(eventId: String): HubData = {
+    val hubData = hubs.getOrElseUpdate(
+      eventId, {
+        val (sink, source) = MergeHub
+          .source[Location]
+          .toMat(BroadcastHub.sink[Location](bufferSize = 128))(Keep.both)
+          .run()
+        HubData(sink, source, new AtomicLong(clock.millis()))
+      }
     )
+    hubData.lastAccessed.set(clock.millis())
+    hubData
+  }
 
   def publish(eventId: String, location: Location): Unit = {
-    val (sink, _) = getOrCreateHub(eventId)
-    Source.single(location).runWith(sink)
+    val hubData = getOrCreateHub(eventId)
+    Source.single(location).runWith(hubData.sink)
   }
 
   def subscribe(eventId: String): Source[Location, NotUsed] = {
-    val (_, source) = getOrCreateHub(eventId)
-    source
+    val hubData = getOrCreateHub(eventId)
+    hubData.source
+  }
+
+  def cleanupUnusedHubs(ttlMillis: Long): Int = {
+    val now       = clock.millis()
+    val threshold = now - ttlMillis
+    val toRemove  = hubs.filter { case (_, hubData) => hubData.lastAccessed.get() < threshold }.keys.toList
+    toRemove.foreach(hubs.remove)
+    toRemove.size
   }
 }

--- a/src/main/scala/skatemap/infra/SkatemapLiveModule.scala
+++ b/src/main/scala/skatemap/infra/SkatemapLiveModule.scala
@@ -57,7 +57,8 @@ class SkatemapLiveModule extends AbstractModule {
   def provideHubConfig(config: Config): HubConfig =
     HubConfig(
       ttl = getPositiveInt(config, "skatemap.hub.ttlSeconds").seconds,
-      cleanupInterval = getPositiveInt(config, "skatemap.hub.cleanupIntervalSeconds").seconds
+      cleanupInterval = getPositiveInt(config, "skatemap.hub.cleanupIntervalSeconds").seconds,
+      bufferSize = getPositiveInt(config, "skatemap.hub.bufferSize")
     )
 
   private def getPositiveInt(config: Config, path: String): Int = {

--- a/src/test/scala/skatemap/api/StreamControllerSpec.scala
+++ b/src/test/scala/skatemap/api/StreamControllerSpec.scala
@@ -10,9 +10,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.stubControllerComponents
 import skatemap.core.{Broadcaster, EventStreamService, LocationStore, StreamConfig}
 import skatemap.domain.Location
-import skatemap.test.LogCapture
+import skatemap.test.{LogCapture, TestClock}
 
-import java.time.{Clock, Instant, ZoneId}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -35,7 +34,7 @@ class StreamControllerSpec extends AnyWordSpec with Matchers {
         new MockLocationStore(),
         new MockBroadcaster(),
         StreamConfig(100, 500.millis),
-        Clock.fixed(Instant.ofEpochMilli(1234567890123L), ZoneId.systemDefault())
+        TestClock.fixed(1234567890123L)
       ) {
     override def createEventStream(eventId: String): Source[String, NotUsed] =
       Source.single("test-data")
@@ -46,7 +45,7 @@ class StreamControllerSpec extends AnyWordSpec with Matchers {
         new MockLocationStore(),
         new MockBroadcaster(),
         StreamConfig(100, 500.millis),
-        Clock.fixed(Instant.ofEpochMilli(1234567890123L), ZoneId.systemDefault())
+        TestClock.fixed(1234567890123L)
       ) {
     override def createEventStream(eventId: String): Source[String, NotUsed] =
       Source.failed(new RuntimeException("Stream processing error"))

--- a/src/test/scala/skatemap/core/BroadcasterCleanupServiceSpec.scala
+++ b/src/test/scala/skatemap/core/BroadcasterCleanupServiceSpec.scala
@@ -1,0 +1,141 @@
+package skatemap.core
+
+import org.apache.pekko.actor.ActorSystem
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.ApplicationLifecycle
+import skatemap.test.LogCapture
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+class BroadcasterCleanupServiceSpec
+    extends AnyWordSpec
+    with Matchers
+    with Eventually
+    with MockitoSugar
+    with BeforeAndAfterAll {
+
+  "BroadcasterCleanupService" should {
+
+    "initialise with configured values" in {
+      val mockBroadcaster = mock[InMemoryBroadcaster]
+      val mockLifecycle   = mock[ApplicationLifecycle]
+      val actorSystem     = ActorSystem("test")
+      val config          = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds)
+
+      when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenReturn(0)
+      doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
+
+      try
+        LogCapture.withCapture("skatemap.core.BroadcasterCleanupService") { capture =>
+          new BroadcasterCleanupService(mockBroadcaster, config, actorSystem, mockLifecycle, actorSystem.dispatcher)
+
+          capture.hasMessageContaining("BroadcasterCleanupService initialised") should be(true)
+          capture.hasMessageContaining("ttl=300 seconds") should be(true)
+          capture.hasMessageContaining("cleanupInterval=60 seconds") should be(true)
+        }
+      finally {
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, 5.seconds)
+      }
+    }
+
+    "schedule cleanup at configured interval and log when hubs are removed" in {
+      val mockBroadcaster = mock[InMemoryBroadcaster]
+      val mockLifecycle   = mock[ApplicationLifecycle]
+      val actorSystem     = ActorSystem("test")
+      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis)
+
+      when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenReturn(2)
+      doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
+
+      try
+        LogCapture.withCapture("skatemap.core.BroadcasterCleanupService") { capture =>
+          new BroadcasterCleanupService(mockBroadcaster, config, actorSystem, mockLifecycle, actorSystem.dispatcher)
+
+          eventually(timeout(Span(2, Seconds)), interval(Span(100, Millis))) {
+            capture.hasMessageContaining("Hub cleanup completed") should be(true)
+            capture.hasMessageContaining("removed 2 hubs") should be(true)
+          }
+        }
+      finally {
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, 5.seconds)
+      }
+    }
+
+    "not log when no hubs are removed" in {
+      val mockBroadcaster = mock[InMemoryBroadcaster]
+      val mockLifecycle   = mock[ApplicationLifecycle]
+      val actorSystem     = ActorSystem("test")
+      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis)
+
+      when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenReturn(0)
+      doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
+
+      try
+        LogCapture.withCapture("skatemap.core.BroadcasterCleanupService") { capture =>
+          new BroadcasterCleanupService(mockBroadcaster, config, actorSystem, mockLifecycle, actorSystem.dispatcher)
+
+          eventually(timeout(Span(2, Seconds)), interval(Span(100, Millis))) {
+            verify(mockBroadcaster, atLeastOnce()).cleanupUnusedHubs(any[Long])
+            capture.hasMessageContaining("Hub cleanup completed") should be(false)
+          }
+        }
+      finally {
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, 5.seconds)
+      }
+    }
+
+    "log cleanup errors" in {
+      val mockBroadcaster = mock[InMemoryBroadcaster]
+      val mockLifecycle   = mock[ApplicationLifecycle]
+      val actorSystem     = ActorSystem("test")
+      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis)
+
+      when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenThrow(new RuntimeException("Cleanup error"))
+      doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
+
+      try
+        LogCapture.withCapture("skatemap.core.BroadcasterCleanupService") { capture =>
+          new BroadcasterCleanupService(mockBroadcaster, config, actorSystem, mockLifecycle, actorSystem.dispatcher)
+
+          eventually(timeout(Span(2, Seconds)), interval(Span(100, Millis))) {
+            capture.hasMessageContaining("Hub cleanup failed") should be(true)
+            capture.hasMessageContaining("Cleanup error") should be(true)
+          }
+        }
+      finally {
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, 5.seconds)
+      }
+    }
+
+    "cancel scheduled cleanup on application shutdown" in {
+      val mockBroadcaster = mock[InMemoryBroadcaster]
+      val mockLifecycle   = mock[ApplicationLifecycle]
+      val actorSystem     = ActorSystem("test")
+      val config          = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds)
+
+      when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenReturn(0)
+      doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
+
+      try {
+        new BroadcasterCleanupService(mockBroadcaster, config, actorSystem, mockLifecycle, actorSystem.dispatcher)
+
+        verify(mockLifecycle).addStopHook(any[() => Future[_]])
+      } finally {
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, 5.seconds)
+      }
+    }
+  }
+}

--- a/src/test/scala/skatemap/core/BroadcasterCleanupServiceSpec.scala
+++ b/src/test/scala/skatemap/core/BroadcasterCleanupServiceSpec.scala
@@ -28,7 +28,7 @@ class BroadcasterCleanupServiceSpec
       val mockBroadcaster = mock[InMemoryBroadcaster]
       val mockLifecycle   = mock[ApplicationLifecycle]
       val actorSystem     = ActorSystem("test")
-      val config          = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds)
+      val config          = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds, bufferSize = 128)
 
       when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenReturn(0)
       doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
@@ -51,7 +51,7 @@ class BroadcasterCleanupServiceSpec
       val mockBroadcaster = mock[InMemoryBroadcaster]
       val mockLifecycle   = mock[ApplicationLifecycle]
       val actorSystem     = ActorSystem("test")
-      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis)
+      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis, bufferSize = 128)
 
       when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenReturn(2)
       doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
@@ -75,7 +75,7 @@ class BroadcasterCleanupServiceSpec
       val mockBroadcaster = mock[InMemoryBroadcaster]
       val mockLifecycle   = mock[ApplicationLifecycle]
       val actorSystem     = ActorSystem("test")
-      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis)
+      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis, bufferSize = 128)
 
       when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenReturn(0)
       doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
@@ -99,7 +99,7 @@ class BroadcasterCleanupServiceSpec
       val mockBroadcaster = mock[InMemoryBroadcaster]
       val mockLifecycle   = mock[ApplicationLifecycle]
       val actorSystem     = ActorSystem("test")
-      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis)
+      val config          = HubConfig(ttl = 1.second, cleanupInterval = 100.millis, bufferSize = 128)
 
       when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenThrow(new RuntimeException("Cleanup error"))
       doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])
@@ -123,7 +123,7 @@ class BroadcasterCleanupServiceSpec
       val mockBroadcaster = mock[InMemoryBroadcaster]
       val mockLifecycle   = mock[ApplicationLifecycle]
       val actorSystem     = ActorSystem("test")
-      val config          = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds)
+      val config          = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds, bufferSize = 128)
 
       when(mockBroadcaster.cleanupUnusedHubs(any[Long])).thenReturn(0)
       doNothing().when(mockLifecycle).addStopHook(any[() => Future[_]])

--- a/src/test/scala/skatemap/core/BroadcasterSpec.scala
+++ b/src/test/scala/skatemap/core/BroadcasterSpec.scala
@@ -10,6 +10,7 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpecLike
 import skatemap.domain.Location
 
+import java.time.Clock
 import scala.concurrent.duration._
 
 class BroadcasterSpec
@@ -27,7 +28,7 @@ class BroadcasterSpec
   override def afterAll(): Unit =
     TestKit.shutdownActorSystem(system)
 
-  private def createBroadcaster(): InMemoryBroadcaster = new InMemoryBroadcaster(system)
+  private def createBroadcaster(): InMemoryBroadcaster = new InMemoryBroadcaster(system, Clock.systemUTC())
 
   private val event1    = "event-1"
   private val event2    = "event-2"

--- a/src/test/scala/skatemap/core/BroadcasterSpec.scala
+++ b/src/test/scala/skatemap/core/BroadcasterSpec.scala
@@ -28,7 +28,14 @@ class BroadcasterSpec
   override def afterAll(): Unit =
     TestKit.shutdownActorSystem(system)
 
-  private def createBroadcaster(): InMemoryBroadcaster = new InMemoryBroadcaster(system, Clock.systemUTC())
+  private val defaultConfig = HubConfig(
+    ttl = 300.seconds,
+    cleanupInterval = 60.seconds,
+    bufferSize = 128
+  )
+
+  private def createBroadcaster(): InMemoryBroadcaster =
+    new InMemoryBroadcaster(system, Clock.systemUTC(), defaultConfig)
 
   private val event1    = "event-1"
   private val event2    = "event-2"

--- a/src/test/scala/skatemap/core/EventStreamServiceSpec.scala
+++ b/src/test/scala/skatemap/core/EventStreamServiceSpec.scala
@@ -11,8 +11,8 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.libs.json.{Format, Json}
 import skatemap.domain.{Location, LocationBatch}
+import skatemap.test.TestClock
 
-import java.time.{Clock, Instant, ZoneId}
 import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.duration._
 
@@ -66,7 +66,7 @@ class EventStreamServiceSpec
       val fixedTime   = 1234567890123L
       val store       = new MockLocationStore()
       val broadcaster = new MockBroadcaster()
-      val clock       = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val clock       = TestClock.fixed(fixedTime)
       val service     = new EventStreamService(store, broadcaster, StreamConfig(100, 500.millis), clock)
 
       noException should be thrownBy service.createEventStream(eventId)
@@ -79,7 +79,7 @@ class EventStreamServiceSpec
       val fixedTime   = 1234567890123L
       val store       = new MockLocationStore()
       val broadcaster = new MockBroadcaster()
-      val clock       = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val clock       = TestClock.fixed(fixedTime)
       val service     = new EventStreamService(store, broadcaster, StreamConfig(100, 500.millis), clock)
 
       store.put(eventId, location1)
@@ -102,7 +102,7 @@ class EventStreamServiceSpec
         override def subscribe(eventId: String): Source[Location, NotUsed] =
           Source(List(location1, location2))
       }
-      val clock   = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val clock   = TestClock.fixed(fixedTime)
       val service = new EventStreamService(store, broadcaster, StreamConfig(100, 500.millis), clock)
 
       val result = service.createEventStream(eventId).take(1).runWith(Sink.head).futureValue
@@ -123,7 +123,7 @@ class EventStreamServiceSpec
         override def subscribe(eventId: String): Source[Location, NotUsed] =
           Source(List(location3))
       }
-      val clock   = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val clock   = TestClock.fixed(fixedTime)
       val service = new EventStreamService(store, broadcaster, StreamConfig(100, 500.millis), clock)
 
       store.put(eventId, location1)
@@ -143,7 +143,7 @@ class EventStreamServiceSpec
       val fixedTime   = 1234567890123L
       val store       = new MockLocationStore()
       val broadcaster = new MockBroadcaster()
-      val clock       = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val clock       = TestClock.fixed(fixedTime)
       val service     = new EventStreamService(store, broadcaster, StreamConfig(100, 500.millis), clock)
 
       store.put(eventId, location1)

--- a/src/test/scala/skatemap/core/HubConfigSpec.scala
+++ b/src/test/scala/skatemap/core/HubConfigSpec.scala
@@ -10,17 +10,19 @@ class HubConfigSpec extends AnyWordSpec with Matchers {
   "HubConfig" should {
 
     "be created with valid values" in {
-      val config = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds)
+      val config = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds, bufferSize = 128)
 
       config.ttl should be(300.seconds)
       config.cleanupInterval should be(60.seconds)
+      config.bufferSize should be(128)
     }
 
     "support different time units" in {
-      val config = HubConfig(ttl = 5.minutes, cleanupInterval = 1.minute)
+      val config = HubConfig(ttl = 5.minutes, cleanupInterval = 1.minute, bufferSize = 256)
 
       config.ttl should be(300.seconds)
       config.cleanupInterval should be(60.seconds)
+      config.bufferSize should be(256)
     }
   }
 }

--- a/src/test/scala/skatemap/core/HubConfigSpec.scala
+++ b/src/test/scala/skatemap/core/HubConfigSpec.scala
@@ -1,0 +1,26 @@
+package skatemap.core
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration._
+
+class HubConfigSpec extends AnyWordSpec with Matchers {
+
+  "HubConfig" should {
+
+    "be created with valid values" in {
+      val config = HubConfig(ttl = 300.seconds, cleanupInterval = 60.seconds)
+
+      config.ttl should be(300.seconds)
+      config.cleanupInterval should be(60.seconds)
+    }
+
+    "support different time units" in {
+      val config = HubConfig(ttl = 5.minutes, cleanupInterval = 1.minute)
+
+      config.ttl should be(300.seconds)
+      config.cleanupInterval should be(60.seconds)
+    }
+  }
+}

--- a/src/test/scala/skatemap/core/InMemoryBroadcasterSpec.scala
+++ b/src/test/scala/skatemap/core/InMemoryBroadcasterSpec.scala
@@ -1,0 +1,155 @@
+package skatemap.core
+
+import org.apache.pekko.actor.ActorSystem
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import skatemap.domain.Location
+
+import java.time.{Clock, Instant, ZoneId}
+import java.util.UUID
+
+class InMemoryBroadcasterSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  implicit val system: ActorSystem = ActorSystem("test")
+
+  override def afterAll(): Unit =
+    system.terminate()
+
+  "InMemoryBroadcaster" should {
+
+    "track last accessed timestamp when hub is created" in {
+      val fixedTime   = 1234567890000L
+      val clock       = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val broadcaster = new InMemoryBroadcaster(system, clock)
+      val eventId     = UUID.randomUUID().toString
+
+      broadcaster.publish(eventId, Location(UUID.randomUUID().toString, 1.0, 2.0, fixedTime))
+
+      broadcaster.hubs.contains(eventId) should be(true)
+      broadcaster.hubs(eventId).lastAccessed.get() should be(fixedTime)
+    }
+
+    "update last accessed timestamp on publish" in {
+      val initialTime = 1000000000000L
+      val laterTime   = 2000000000000L
+      val clock       = Clock.fixed(Instant.ofEpochMilli(initialTime), ZoneId.systemDefault())
+      val broadcaster = new InMemoryBroadcaster(system, clock)
+      val eventId     = UUID.randomUUID().toString
+
+      broadcaster.publish(eventId, Location(UUID.randomUUID().toString, 1.0, 2.0, initialTime))
+      val firstTimestamp = broadcaster.hubs(eventId).lastAccessed.get()
+
+      broadcaster.hubs(eventId).lastAccessed.set(initialTime)
+
+      val updatedClock = Clock.fixed(Instant.ofEpochMilli(laterTime), ZoneId.systemDefault())
+      val broadcaster2 = new InMemoryBroadcaster(system, updatedClock)
+      val hub          = broadcaster.hubs(eventId)
+      broadcaster2.hubs.put(eventId, broadcaster2.HubData(hub.sink, hub.source, hub.lastAccessed))
+
+      broadcaster2.publish(eventId, Location(UUID.randomUUID().toString, 3.0, 4.0, laterTime))
+      val secondTimestamp = broadcaster2.hubs(eventId).lastAccessed.get()
+
+      secondTimestamp should be > firstTimestamp
+    }
+
+    "update last accessed timestamp on subscribe" in {
+      val initialTime = 1000000000000L
+      val laterTime   = 2000000000000L
+      val clock       = Clock.fixed(Instant.ofEpochMilli(initialTime), ZoneId.systemDefault())
+      val broadcaster = new InMemoryBroadcaster(system, clock)
+      val eventId     = UUID.randomUUID().toString
+
+      broadcaster.subscribe(eventId)
+      val firstTimestamp = broadcaster.hubs(eventId).lastAccessed.get()
+
+      broadcaster.hubs(eventId).lastAccessed.set(initialTime)
+
+      val updatedClock = Clock.fixed(Instant.ofEpochMilli(laterTime), ZoneId.systemDefault())
+      val broadcaster2 = new InMemoryBroadcaster(system, updatedClock)
+      val hub          = broadcaster.hubs(eventId)
+      broadcaster2.hubs.put(eventId, broadcaster2.HubData(hub.sink, hub.source, hub.lastAccessed))
+
+      broadcaster2.subscribe(eventId)
+      val secondTimestamp = broadcaster2.hubs(eventId).lastAccessed.get()
+
+      secondTimestamp should be > firstTimestamp
+    }
+
+    "cleanup unused hubs based on TTL" in {
+      val fixedTime   = 1000000000000L
+      val clock       = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val broadcaster = new InMemoryBroadcaster(system, clock)
+      val eventId1    = UUID.randomUUID().toString
+      val eventId2    = UUID.randomUUID().toString
+
+      broadcaster.publish(eventId1, Location(UUID.randomUUID().toString, 1.0, 2.0, fixedTime))
+      broadcaster.publish(eventId2, Location(UUID.randomUUID().toString, 3.0, 4.0, fixedTime))
+
+      broadcaster.hubs.size should be(2)
+
+      val ttlMillis    = 5000L
+      val laterTime    = fixedTime + ttlMillis + 1000L
+      val laterClock   = Clock.fixed(Instant.ofEpochMilli(laterTime), ZoneId.systemDefault())
+      val broadcaster2 = new InMemoryBroadcaster(system, laterClock)
+
+      broadcaster.hubs.foreachEntry { (key, hub) =>
+        broadcaster2.hubs.put(key, broadcaster2.HubData(hub.sink, hub.source, hub.lastAccessed))
+      }
+
+      val removed = broadcaster2.cleanupUnusedHubs(ttlMillis)
+
+      removed should be(2)
+      broadcaster2.hubs.size should be(0)
+    }
+
+    "not cleanup recently accessed hubs" in {
+      val fixedTime   = 1000000000000L
+      val clock       = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val broadcaster = new InMemoryBroadcaster(system, clock)
+      val eventId     = UUID.randomUUID().toString
+
+      broadcaster.publish(eventId, Location(UUID.randomUUID().toString, 1.0, 2.0, fixedTime))
+
+      val ttlMillis    = 5000L
+      val laterTime    = fixedTime + ttlMillis - 1000L
+      val laterClock   = Clock.fixed(Instant.ofEpochMilli(laterTime), ZoneId.systemDefault())
+      val broadcaster2 = new InMemoryBroadcaster(system, laterClock)
+
+      val hub = broadcaster.hubs(eventId)
+      broadcaster2.hubs.put(eventId, broadcaster2.HubData(hub.sink, hub.source, hub.lastAccessed))
+
+      val removed = broadcaster2.cleanupUnusedHubs(ttlMillis)
+
+      removed should be(0)
+      broadcaster2.hubs.size should be(1)
+    }
+
+    "return count of removed hubs" in {
+      val fixedTime   = 1000000000000L
+      val clock       = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneId.systemDefault())
+      val broadcaster = new InMemoryBroadcaster(system, clock)
+
+      val eventIds = (1 to 5).map(_ => UUID.randomUUID().toString)
+      eventIds.foreach { eventId =>
+        broadcaster.publish(eventId, Location(UUID.randomUUID().toString, 1.0, 2.0, fixedTime))
+      }
+
+      broadcaster.hubs.size should be(5)
+
+      val ttlMillis    = 1000L
+      val laterTime    = fixedTime + ttlMillis + 1L
+      val laterClock   = Clock.fixed(Instant.ofEpochMilli(laterTime), ZoneId.systemDefault())
+      val broadcaster2 = new InMemoryBroadcaster(system, laterClock)
+
+      broadcaster.hubs.foreachEntry { (key, hub) =>
+        broadcaster2.hubs.put(key, broadcaster2.HubData(hub.sink, hub.source, hub.lastAccessed))
+      }
+
+      val removed = broadcaster2.cleanupUnusedHubs(ttlMillis)
+
+      removed should be(5)
+      broadcaster2.hubs.size should be(0)
+    }
+  }
+}

--- a/src/test/scala/skatemap/core/InMemoryBroadcasterSpec.scala
+++ b/src/test/scala/skatemap/core/InMemoryBroadcasterSpec.scala
@@ -56,8 +56,7 @@ class InMemoryBroadcasterSpec extends AnyWordSpec with Matchers with BeforeAndAf
 
       val updatedClock = TestClock.fixed(laterTime)
       val broadcaster2 = new InMemoryBroadcaster(system, updatedClock, defaultConfig)
-      val hub          = broadcaster.hubs(eventId)
-      broadcaster2.hubs.put(eventId, broadcaster2.HubData(hub.sink, hub.source, hub.lastAccessed))
+      transferHubs(broadcaster, broadcaster2)
 
       broadcaster2.publish(eventId, Location(UUID.randomUUID().toString, 3.0, 4.0, laterTime))
       val secondTimestamp = broadcaster2.hubs(eventId).lastAccessed.get()
@@ -79,8 +78,7 @@ class InMemoryBroadcasterSpec extends AnyWordSpec with Matchers with BeforeAndAf
 
       val updatedClock = TestClock.fixed(laterTime)
       val broadcaster2 = new InMemoryBroadcaster(system, updatedClock, defaultConfig)
-      val hub          = broadcaster.hubs(eventId)
-      broadcaster2.hubs.put(eventId, broadcaster2.HubData(hub.sink, hub.source, hub.lastAccessed))
+      transferHubs(broadcaster, broadcaster2)
 
       broadcaster2.subscribe(eventId)
       val secondTimestamp = broadcaster2.hubs(eventId).lastAccessed.get()

--- a/src/test/scala/skatemap/core/LocationStoreSpec.scala
+++ b/src/test/scala/skatemap/core/LocationStoreSpec.scala
@@ -1,14 +1,14 @@
 package skatemap.core
 
 import skatemap.domain.Location
+import skatemap.test.TestClock
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
-import java.time.{Clock, Instant, ZoneOffset}
 import scala.concurrent.duration._
 
 class LocationStoreSpec extends AnyWordSpec with Matchers {
 
-  private val fixedClock = Clock.fixed(Instant.ofEpochMilli(50000L), ZoneOffset.UTC)
+  private val fixedClock = TestClock.fixed(50000L)
   private val config     = LocationConfig(ttl = 30.seconds)
 
   "InMemoryLocationStore" should {

--- a/src/test/scala/skatemap/infra/SkatemapLiveModuleSpec.scala
+++ b/src/test/scala/skatemap/infra/SkatemapLiveModuleSpec.scala
@@ -288,6 +288,7 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
     "fail when ttlSeconds config path is missing" in {
       val config = ConfigFactory.parseString("""
         skatemap.hub.cleanupIntervalSeconds = 60
+        skatemap.hub.bufferSize = 128
       """)
       val module = new SkatemapLiveModule
 
@@ -300,6 +301,7 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
     "fail when cleanupIntervalSeconds config path is missing" in {
       val config = ConfigFactory.parseString("""
         skatemap.hub.ttlSeconds = 300
+        skatemap.hub.bufferSize = 128
       """)
       val module = new SkatemapLiveModule
 
@@ -323,6 +325,7 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
       val config = ConfigFactory.parseString("""
         skatemap.hub.ttlSeconds = 0
         skatemap.hub.cleanupIntervalSeconds = 60
+        skatemap.hub.bufferSize = 128
       """)
       val module = new SkatemapLiveModule
 
@@ -338,6 +341,7 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
       val config = ConfigFactory.parseString("""
         skatemap.hub.ttlSeconds = -300
         skatemap.hub.cleanupIntervalSeconds = 60
+        skatemap.hub.bufferSize = 128
       """)
       val module = new SkatemapLiveModule
 
@@ -353,6 +357,7 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
       val config = ConfigFactory.parseString("""
         skatemap.hub.ttlSeconds = 300
         skatemap.hub.cleanupIntervalSeconds = 0
+        skatemap.hub.bufferSize = 128
       """)
       val module = new SkatemapLiveModule
 
@@ -368,6 +373,7 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
       val config = ConfigFactory.parseString("""
         skatemap.hub.ttlSeconds = 300
         skatemap.hub.cleanupIntervalSeconds = -60
+        skatemap.hub.bufferSize = 128
       """)
       val module = new SkatemapLiveModule
 
@@ -379,10 +385,56 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
       )
     }
 
-    "use configured values when both are present and positive" in {
+    "fail when bufferSize config path is missing" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = 300
+        skatemap.hub.cleanupIntervalSeconds = 60
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include("Required configuration missing: skatemap.hub.bufferSize")
+    }
+
+    "fail when bufferSize is zero" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = 300
+        skatemap.hub.cleanupIntervalSeconds = 60
+        skatemap.hub.bufferSize = 0
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include(
+        "Invalid configuration: skatemap.hub.bufferSize=0 (must be positive)"
+      )
+    }
+
+    "fail when bufferSize is negative" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = 300
+        skatemap.hub.cleanupIntervalSeconds = 60
+        skatemap.hub.bufferSize = -128
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include(
+        "Invalid configuration: skatemap.hub.bufferSize=-128 (must be positive)"
+      )
+    }
+
+    "use configured values when all are present and positive" in {
       val config = ConfigFactory.parseString("""
         skatemap.hub.ttlSeconds = 150
         skatemap.hub.cleanupIntervalSeconds = 30
+        skatemap.hub.bufferSize = 256
       """)
       val module = new SkatemapLiveModule
 
@@ -390,6 +442,7 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
 
       hubConfig.ttl shouldBe 150.seconds
       hubConfig.cleanupInterval shouldBe 30.seconds
+      hubConfig.bufferSize shouldBe 256
     }
 
   }

--- a/src/test/scala/skatemap/infra/SkatemapLiveModuleSpec.scala
+++ b/src/test/scala/skatemap/infra/SkatemapLiveModuleSpec.scala
@@ -283,4 +283,115 @@ class SkatemapLiveModuleSpec extends AnyWordSpec with Matchers {
 
   }
 
+  "SkatemapLiveModule.provideHubConfig" should {
+
+    "fail when ttlSeconds config path is missing" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.cleanupIntervalSeconds = 60
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include("Required configuration missing: skatemap.hub.ttlSeconds")
+    }
+
+    "fail when cleanupIntervalSeconds config path is missing" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = 300
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include("Required configuration missing: skatemap.hub.cleanupIntervalSeconds")
+    }
+
+    "fail when both config paths are missing" in {
+      val config = ConfigFactory.empty()
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include("Required configuration missing")
+    }
+
+    "fail when ttlSeconds is zero" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = 0
+        skatemap.hub.cleanupIntervalSeconds = 60
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include(
+        "Invalid configuration: skatemap.hub.ttlSeconds=0 (must be positive)"
+      )
+    }
+
+    "fail when ttlSeconds is negative" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = -300
+        skatemap.hub.cleanupIntervalSeconds = 60
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include(
+        "Invalid configuration: skatemap.hub.ttlSeconds=-300 (must be positive)"
+      )
+    }
+
+    "fail when cleanupIntervalSeconds is zero" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = 300
+        skatemap.hub.cleanupIntervalSeconds = 0
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include(
+        "Invalid configuration: skatemap.hub.cleanupIntervalSeconds=0 (must be positive)"
+      )
+    }
+
+    "fail when cleanupIntervalSeconds is negative" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = 300
+        skatemap.hub.cleanupIntervalSeconds = -60
+      """)
+      val module = new SkatemapLiveModule
+
+      val exception = intercept[IllegalArgumentException] {
+        module.provideHubConfig(config)
+      }
+      exception.getMessage should include(
+        "Invalid configuration: skatemap.hub.cleanupIntervalSeconds=-60 (must be positive)"
+      )
+    }
+
+    "use configured values when both are present and positive" in {
+      val config = ConfigFactory.parseString("""
+        skatemap.hub.ttlSeconds = 150
+        skatemap.hub.cleanupIntervalSeconds = 30
+      """)
+      val module = new SkatemapLiveModule
+
+      val hubConfig = module.provideHubConfig(config)
+
+      hubConfig.ttl shouldBe 150.seconds
+      hubConfig.cleanupInterval shouldBe 30.seconds
+    }
+
+  }
+
 }

--- a/src/test/scala/skatemap/test/TestClock.scala
+++ b/src/test/scala/skatemap/test/TestClock.scala
@@ -1,0 +1,9 @@
+package skatemap.test
+
+import java.time.{Clock, Instant, ZoneId}
+
+object TestClock {
+
+  def fixed(epochMillis: Long): Clock =
+    Clock.fixed(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault())
+}


### PR DESCRIPTION
## Summary

This PR implements the improvements requested in issue #67, based on feedback from PR #65:

- **EventId validation in StreamController**: Validates UUID format before accepting WebSocket connections, returning 400 Bad Request for invalid event IDs
- **Hub cleanup mechanism for InMemoryBroadcaster**: Prevents memory leaks by tracking last access timestamps and periodically removing unused hubs
  - Added `HubConfig` for configurable TTL, cleanup interval, and buffer size
  - Created `BroadcasterCleanupService` for scheduled cleanup using Pekko ActorSystem scheduler
  - Hub cleanup runs every 60 seconds and removes hubs unused for 5 minutes (configurable)
- **Documentation**: Added hub configuration rationale to CLAUDE.md explaining TTL design decisions

## Code Quality Improvements

- **Test utilities**: Created `TestClock` utility for reusable fixed clock creation across test suites
- **Test helpers**: Added `transferHubs` helper method in `InMemoryBroadcasterSpec` to reduce duplication
- **Configurable buffer size**: Made WebSocket broadcast hub buffer size configurable via `HubConfig.bufferSize`
  - Previously hardcoded to 128, now configurable in `application.conf`
  - Added comprehensive validation and tests for buffer size configuration

## Test plan

- [x] All 183 tests passing
- [x] 100% statement and branch coverage maintained
- [x] Added comprehensive tests for hub cleanup logic
- [x] Added tests for StreamController eventId validation
- [x] Added tests for configurable buffer size
- [x] Verified Scalafmt and Scalastyle compliance
- [x] Verified Wartremover checks pass

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)