### PR TITLE
refactor: replace test mocks with production implementations

### DIFF
--- a/src/test/scala/skatemap/test/StubBroadcaster.scala
+++ b/src/test/scala/skatemap/test/StubBroadcaster.scala
@@ -1,0 +1,11 @@
+package skatemap.test
+
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.Source
+import skatemap.core.Broadcaster
+import skatemap.domain.Location
+
+class StubBroadcaster extends Broadcaster {
+  def publish(eventId: String, location: Location): Unit    = ()
+  def subscribe(eventId: String): Source[Location, NotUsed] = Source.empty
+}


### PR DESCRIPTION
## Summary

Replace custom `MockLocationStore` implementations with `InMemoryLocationStore` in all test files. This ensures tests verify actual production behaviour including TTL logic, whilst eliminating duplicated storage code.

## Changes

- Use `InMemoryLocationStore` with `TestClock` in all spec files (StreamControllerSpec, LocationControllerSpec, EventStreamServiceSpec)
- Add `StubBroadcaster` as shared test helper (11 lines)
- Remove 38 lines of duplicated mock storage code that was previously in three separate test files

## Benefits

- Tests now verify actual production behaviour including TTL logic
- If `InMemoryLocationStore` changes, tests automatically validate those changes
- Less code to maintain - no separate mocks to keep in sync
- More realistic testing - using what actually runs in production

## Test plan

- [x] All 116 tests pass
- [x] Pre-commit hooks pass (scalafmt, commit message format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)