### PR TITLE
fix: increase WebSocket idle timeout to 3 minutes

### DIFF
--- a/services/api/src/main/resources/application.conf
+++ b/services/api/src/main/resources/application.conf
@@ -7,6 +7,9 @@ play.filters.hosts.allowed = [".up.railway.app", "healthcheck.railway.app", "loc
 play.server.http.port = 9000
 play.server.http.port = ${?PORT}
 
+pekko.http.server.idle-timeout = 3 minutes
+pekko.http.server.idle-timeout = ${?WEBSOCKET_IDLE_TIMEOUT}
+
 skatemap {
   cleanup {
     initialDelaySeconds = 10


### PR DESCRIPTION
## Summary

Fixes WebSocket connection drops during manual smoke testing by increasing the Pekko HTTP idle timeout.

## Changes

- Set `pekko.http.server.idle-timeout` to 3 minutes (from default 75 seconds)
- Configurable via `WEBSOCKET_IDLE_TIMEOUT` environment variable
- No keep-alive pings configured (unnecessary overhead)

## Problem

During manual smoke testing (issue #110), WebSocket connections were being dropped after ~2 minutes with "connection reset by peer" errors. Railway logs showed:

```
WebSocket communication problem: HTTP idle-timeout encountered, no bytes passed in the last 75 seconds.
```

## Solution

Increase the idle timeout to 3 minutes. This provides sufficient buffer for manual testing pauses whilst cleaning up dead connections in a reasonable timeframe.

**Why no keep-alive pings?**

Keep-alive pings are unnecessary for this application:
- **Active events:** Location updates flow every 2-3 seconds - connection never idle
- **Dead events:** Should expire naturally (30s TTL + 10s cleanup) - no point keeping connection alive
- **Manual testing:** Pauses are under 3 minutes - simple timeout increase solves this

Keep-alive would add ~1-2 pings/second overhead with 50 viewers without providing value.

## Configuration

Default: 3 minutes

Override via environment variable (expects duration string):
```bash
WEBSOCKET_IDLE_TIMEOUT="5m"      # 5 minutes
WEBSOCKET_IDLE_TIMEOUT="180s"    # 180 seconds
```

Note: The environment variable expects a duration string (e.g., "5m", "180s", "3 minutes"), not a plain integer.

## Testing

- Deploy to Railway
- Re-run Phase 1 of manual smoke test from `docs/load-testing/manual-smoke-test-plan.md`
- WebSocket connections should remain stable during testing pauses

## Related

- #110 - Manual smoke test issue
- #133 - Follow-up issue for integration test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)