### PR TITLE
feat: add --event-id flag to simulate-skaters

### DIFF
--- a/tools/load-testing/cmd/simulate-skaters/main.go
+++ b/tools/load-testing/cmd/simulate-skaters/main.go
@@ -99,8 +99,11 @@ func parseEventIDs(eventIDsStr string, numEvents int) ([]string, error) {
 	}
 
 	for i, id := range eventIDs {
+		if id == "" {
+			return nil, fmt.Errorf("empty event ID at position %d", i+1)
+		}
 		if _, err := uuid.Parse(id); err != nil {
-			return nil, fmt.Errorf("invalid UUID format for event ID %d: %s", i+1, id)
+			return nil, fmt.Errorf("invalid UUID format for event ID %d (%s): %w", i+1, id, err)
 		}
 	}
 

--- a/tools/load-testing/cmd/simulate-skaters/main_test.go
+++ b/tools/load-testing/cmd/simulate-skaters/main_test.go
@@ -138,7 +138,7 @@ func TestParseEventIDs_EmptyUUID(t *testing.T) {
 		t.Fatal("Expected error for empty UUID, got nil")
 	}
 
-	expectedMsg := "invalid UUID format"
+	expectedMsg := "empty event ID at position 2"
 	if !strings.Contains(err.Error(), expectedMsg) {
 		t.Errorf("Expected error message to contain %q, got: %s", expectedMsg, err.Error())
 	}


### PR DESCRIPTION
## Summary

Adds optional `--event-id` flag to the simulate-skaters tool, allowing users to specify event IDs instead of always generating random ones.

## Motivation

This enables critical testing scenarios that were previously impossible:
- Restarting skater simulations with the same event ID (required for Phase 2.7 WebSocket timeout test)
- Adding more skaters to existing events (required for Phase 4 scale test)
- Testing whether WebSocket connections survive idle periods and can resume receiving data

Without this flag, the manual smoke test plan Phase 2.7 cannot be properly executed.

## Changes

- Added `--event-id` flag that accepts comma-separated UUIDs
- Validates that provided IDs are valid UUIDs
- Validates that number of provided IDs matches `--events` parameter
- Falls back to random generation when flag is not provided (backward compatible)

## Usage

```bash
# Generate event ID on first run
./bin/simulate-skaters \
  --events=1 \
  --skaters-per-event=3 \
  --target-url=$URL \
  --metrics-file=test1.csv
# Note the generated event ID: 550e8400-...

# Restart with same event ID
./bin/simulate-skaters \
  --event-id=550e8400-... \
  --skaters-per-event=3 \
  --target-url=$URL \
  --metrics-file=test2.csv
```

## Testing

- Built and tested with `--help` flag
- Validates UUID format
- Validates count matches `--events` parameter

## Related

- Unblocks Phase 2.7 of manual smoke test plan (docs/load-testing/manual-smoke-test-plan.md)
- Enables Phase 4 scale testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)