### PR TITLE
chore: add Railway heap dump debugging support

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -6,6 +6,3 @@ dockerfilePath = "services/api/Dockerfile.railway"
 startCommand = "/app/docker-entrypoint.sh"
 healthcheckPath = "/health"
 healthcheckTimeout = 100
-
-[[deploy.volumes]]
-mountPath = "/heap-dumps"


### PR DESCRIPTION
## Summary

Enables heap dump collection on Railway to investigate memory leak issue #166.

Related to #166 (enables investigation)

## Problem

Memory leak only reproduces on Railway (93 MB retained indefinitely), not locally. We need Railway heap dumps to identify what objects are being retained.

## Solution

Temporarily switch Dockerfile from JRE to JDK to enable `jcmd` for heap dump generation.

Heap dumps will be written to `/app/heap-dumps` (owned by skatemap user) and retrieved immediately via SSH after generation.

## Changes

- `Dockerfile.railway`: Changed base image from `eclipse-temurin:21-jre` to `eclipse-temurin:21-jdk`

## Workflow

```bash
# SSH into Railway
railway ssh

# Create dumps directory
mkdir -p /app/heap-dumps

# Generate heap dump
jcmd <pid> GC.heap_dump /app/heap-dumps/railway-heap.hprof

# Exit and download for analysis
```

## Revert Plan

After investigation completes and fix is implemented, this PR will be reverted to restore JRE image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)