### PR TITLE
fix: remove NMT flags to eliminate 5-10% overhead

### DIFF
--- a/services/api/build.sbt
+++ b/services/api/build.sbt
@@ -17,8 +17,7 @@ lazy val root = (project in file("."))
     run / javaOptions ++= Seq(
       "-Xlog:gc*=debug:file=gc-%t.log:time,level,tags",
       "-XX:+HeapDumpOnOutOfMemoryError",
-      "-XX:HeapDumpPath=./heap-dumps/",
-      "-XX:NativeMemoryTracking=summary"
+      "-XX:HeapDumpPath=./heap-dumps/"
     ),
     // WartRemover incorrectly analyzes routes files - exclude warts that routes files trigger
     Compile / compile / wartremoverErrors := Warts.allBut(

--- a/services/api/docker-entrypoint.sh
+++ b/services/api/docker-entrypoint.sh
@@ -7,6 +7,4 @@ if [ -z "$APPLICATION_SECRET" ]; then
 fi
 
 # Use exec to replace shell with Java process (ensures proper signal handling)
-exec bin/skatemap-live \
-  -J-XX:NativeMemoryTracking=summary \
-  -Dplay.http.secret.key="${APPLICATION_SECRET}"
+exec bin/skatemap-live -Dplay.http.secret.key="${APPLICATION_SECRET}"


### PR DESCRIPTION
## Summary

Removes `-XX:NativeMemoryTracking=summary` JVM flag from both local development and Railway production deployment after NMT investigation completion.

## Background

**PR #176** (merged 1 Feb 16:03 UTC): Added NMT flags to investigate native memory retention (issue #166)

**PR #178** (merged 1 Feb 23:51 UTC): Completed investigation, identified 50 MB retention as normal JVM warmup behaviour

**Problem:** PR #178's squash merge lost the NMT flag removal changes that were in commit d64f9ab

**Why it happened:**
1. PR #176 merged first and ADDED NMT flags
2. PR #178 branch had commit 72dbbbd that also ADDED the same flags (before #176 merged)  
3. PR #178 branch then had commit d64f9ab that REMOVED the flags
4. When squash merging: base (has flags from #176) vs branch head (add + remove = **net zero change**)
5. GitHub excluded build.sbt and docker-entrypoint.sh from the squash merge entirely

## Impact

Production has been running with **5-10% NMT overhead** since 1 Feb 16:03 UTC when it should have been removed after investigation completed.

## Changes

- Remove `-XX:NativeMemoryTracking=summary` from services/api/build.sbt (local dev)
- Remove `-J-XX:NativeMemoryTracking=summary` from services/api/docker-entrypoint.sh (Railway)

## Testing

Local verification that flags are removed. Railway deployment will confirm overhead eliminated.

Related to #166, PR #176, PR #178

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only removes `-XX:NativeMemoryTracking=summary` JVM options from dev and container startup, which may reduce observability but doesn’t change application logic or data handling.
> 
> **Overview**
> Removes the JVM Native Memory Tracking flag (`-XX:NativeMemoryTracking=summary`) from both local `run / javaOptions` in `services/api/build.sbt` and the production container startup in `services/api/docker-entrypoint.sh` to eliminate runtime overhead.
> 
> Startup now runs `bin/skatemap-live` without the extra `-J-XX:NativeMemoryTracking=summary` option while keeping the Play secret configuration unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7e6f0f8dcb753fed2f8de1ed59904db5aa99c27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->