### PR TITLE
fix: link Railway project in CI for smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -81,9 +81,12 @@ jobs:
         run: |
           echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC') - Linking Railway project with environment"
           railway link --project ${{ secrets.RAILWAY_PROJECT_ID }} --environment ${{ secrets.RAILWAY_ENVIRONMENT_ID }} --service ${{ secrets.RAILWAY_SERVICE_ID }}
-          echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC') - Railway project linked successfully"
+          echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC') - Railway project linked successfully (project: ${{ secrets.RAILWAY_PROJECT_ID }}, environment: ${{ secrets.RAILWAY_ENVIRONMENT_ID }}, service: ${{ secrets.RAILWAY_SERVICE_ID }})"
           echo "$(date -u '+%Y-%m-%d %H:%M:%S UTC') - Verifying Railway connectivity"
-          railway status
+          if ! railway status 2>&1; then
+            echo "::error::Railway status check failed"
+            exit 1
+          fi
 
       - name: Run smoke tests
         if: steps.check-url.outputs.skip == 'false'


### PR DESCRIPTION
## Problem

Scheduled smoke tests (daily at 02:00 UTC) fail because Railway CLI cannot fetch logs in CI environment.

**Error observed:**
```
Error: exit status 1
Messages: Failed to fetch Railway logs
```

**Root cause:**
- Railway CLI runs in unlinked directory in CI
- `railway logs` commands require project context (project/environment/service IDs)
- Even with `RAILWAY_TOKEN` set, CLI doesn't know which project to query
- Local runs work because `~/.railway/config.json` contains project linking

## Solution

This PR adds a Railway project linking step before running smoke tests:

1. **Added `RAILWAY_PROJECT_ID` GitHub secret**
2. **Added workflow step** to run `railway link --project` before tests

The linking step establishes project context, allowing `railway logs --tail N` commands used by test helpers to succeed.

## Changes

- `.github/workflows/smoke-test.yml`: Added "Link Railway project" step

## Testing

After merge, scheduled smoke tests should:
- ✅ Pass TestLocationExpiry (currently failing)
- ✅ Pass all Railway log parsing assertions
- ✅ Complete full 42-minute test suite successfully

## References

Closes #181

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only workflow changes; main risk is misconfigured/missing Railway secrets causing the smoke-test job to fail earlier rather than running tests.
> 
> **Overview**
> Ensures scheduled/manual smoke tests can access Railway project context in CI by **validating required Railway secrets** and **linking the CLI to a specific project/environment/service** (`railway link`) before running tests.
> 
> Pins Railway CLI to `4.27.5`, adds PATH/version logging, and performs a `railway status` connectivity check to fail fast with clearer errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcea5623d695462e2172e8d75c9ef36fd3e1fd01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->