### PR TITLE
chore: improve heap dump gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,6 +252,6 @@ tools/load-testing/*.csv
 *.csv
 
 ### JVM Profiling ###
-heap-dumps/*.hprof
+**/heap-dumps/
 *.hprof
 gc-*.log


### PR DESCRIPTION
## Summary

- Update `.gitignore` pattern from `heap-dumps/*.hprof` to `**/heap-dumps/`
- Matches heap-dumps directories at any level in the project tree
- Prevents future accumulation of heap dumps in nested directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `.gitignore` pattern change; affects only which local profiling artifacts are ignored, with no runtime or production impact.
> 
> **Overview**
> Updates `.gitignore` to ignore `heap-dumps` directories anywhere in the repo (replacing the narrower `heap-dumps/*.hprof` rule), preventing accidental commits of heap dump artifacts from nested paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 564942545535442c299b25020d984e1b68d77ff6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->