### PR TITLE
feat: add OpenTelemetry Java agent to Docker images

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -26,6 +26,9 @@ RUN --mount=type=cache,target=/root/.sbt \
 
 FROM eclipse-temurin:21-jre
 
+ARG OTEL_VERSION=2.24.0
+ARG OTEL_CHECKSUM=5c48cd48f9907f824214e22f14a28375c92613a94b0cf98381997e0a678220ce
+
 RUN apt-get update && \
     apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/* && \
@@ -38,7 +41,8 @@ COPY --from=builder /app/target/universal/stage .
 COPY services/api/docker-entrypoint.sh /app/
 
 RUN curl -fsSL -o /app/opentelemetry-javaagent.jar \
-    https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+    "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_VERSION}/opentelemetry-javaagent.jar" && \
+    echo "${OTEL_CHECKSUM}  /app/opentelemetry-javaagent.jar" | sha256sum -c -
 
 RUN chown -R skatemap:skatemap /app && \
     chmod +x /app/docker-entrypoint.sh

--- a/services/api/Dockerfile.railway
+++ b/services/api/Dockerfile.railway
@@ -29,6 +29,9 @@ RUN --mount=type=cache,id=s/3f2cb6e0-c897-4e0a-b01a-b1025950affe-sbt,target=/roo
 
 FROM eclipse-temurin:21-jre
 
+ARG OTEL_VERSION=2.24.0
+ARG OTEL_CHECKSUM=5c48cd48f9907f824214e22f14a28375c92613a94b0cf98381997e0a678220ce
+
 RUN apt-get update && \
     apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/* && \
@@ -41,7 +44,8 @@ COPY --from=builder /app/target/universal/stage .
 COPY services/api/docker-entrypoint.sh /app/
 
 RUN curl -fsSL -o /app/opentelemetry-javaagent.jar \
-    https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+    "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_VERSION}/opentelemetry-javaagent.jar" && \
+    echo "${OTEL_CHECKSUM}  /app/opentelemetry-javaagent.jar" | sha256sum -c -
 
 RUN chown -R skatemap:skatemap /app && \
     chmod +x /app/docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- Downloads OpenTelemetry Java agent JAR during Docker image build
- Enables auto-instrumentation for observability
- Agent placed at `/app/opentelemetry-javaagent.jar`
- Uses latest stable release from OTel Java instrumentation

## Changes
- Modified `services/api/Dockerfile` to download OTel agent
- Modified `services/api/Dockerfile.railway` to download OTel agent

## Testing
Verified Docker builds complete successfully and agent JAR exists at expected location with correct ownership.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-time change limited to Docker image contents; primary risk is build failures or supply-chain issues if the upstream agent download/checksum is incorrect.
> 
> **Overview**
> Adds the OpenTelemetry Java auto-instrumentation agent to the API runtime Docker images (`Dockerfile` and `Dockerfile.railway`) by downloading `opentelemetry-javaagent.jar` during build.
> 
> Introduces `OTEL_VERSION`/`OTEL_CHECKSUM` build args and verifies the downloaded JAR via SHA-256, placing it at `/app/opentelemetry-javaagent.jar` for later runtime enablement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0117391a721c61c64231626531ca1edadd7838ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->