### PR TITLE
feat: configure JVM to launch with OpenTelemetry agent

### DIFF
--- a/services/api/docker-entrypoint.sh
+++ b/services/api/docker-entrypoint.sh
@@ -7,15 +7,15 @@ if [ -z "$APPLICATION_SECRET" ]; then
 fi
 
 OTEL_AGENT_PATH="/app/opentelemetry-javaagent.jar"
-JAVA_OPTS=""
+OTEL_AGENT_OPTS=""
 
 if [ -f "$OTEL_AGENT_PATH" ]; then
-  JAVA_OPTS="-J-javaagent:$OTEL_AGENT_PATH"
+  OTEL_AGENT_OPTS="-J-javaagent:$OTEL_AGENT_PATH"
 else
   echo "WARNING: OpenTelemetry agent not found at $OTEL_AGENT_PATH, starting without instrumentation" >&2
 fi
 
 # Use exec to replace shell with Java process (ensures proper signal handling)
 exec bin/skatemap-live \
-  $JAVA_OPTS \
+  $OTEL_AGENT_OPTS \
   -Dplay.http.secret.key="${APPLICATION_SECRET}"


### PR DESCRIPTION
## Summary

Modifies the Docker entrypoint script to attach the OpenTelemetry Java agent via the `-javaagent` flag when launching the JVM.

## Changes

- Updated `services/api/docker-entrypoint.sh` to include `-J-javaagent:/app/opentelemetry-javaagent.jar` flag
- Agent will be configured via standard OTEL environment variables in Railway

## Testing

Tested locally:
- ✅ Agent loads successfully (version logged on startup)
- ✅ Application starts successfully with agent attached
- ✅ Graceful degradation works (app continues if agent can't export)

## Environment Variables Required

Set in Railway after merge:
- `OTEL_EXPORTER_OTLP_ENDPOINT` - Honeycomb endpoint
- `OTEL_EXPORTER_OTLP_HEADERS` - Honeycomb API key
- `OTEL_SERVICE_NAME` - Service identifier (optional)

Closes #189

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to the container entrypoint; main risk is startup misconfiguration if the agent jar path/flag is wrong, but it degrades gracefully.
> 
> **Overview**
> Configures the API container startup to **optionally attach the OpenTelemetry Java agent** when launching the app.
> 
> `services/api/docker-entrypoint.sh` now checks for `/app/opentelemetry-javaagent.jar`, adds `-J-javaagent:<path>` when present, and otherwise logs a warning while continuing to start the service normally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d739b52fab7e0e06d0358fe1b5486cf4067bc0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->