### PR TITLE
test: add BATS integration tests for docker-entrypoint.sh

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -59,9 +59,6 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: Install BATS
       run: |
         sudo apt-get update

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -7,12 +7,14 @@ on:
     branches: [ master ]
     paths:
       - '**/*.sh'
+      - '**/*.bats'
       - 'scripts/git-hooks/**'
       - '.github/workflows/shell.yml'
   pull_request:
     branches: [ master ]
     paths:
       - '**/*.sh'
+      - '**/*.bats'
       - 'scripts/git-hooks/**'
       - '.github/workflows/shell.yml'
 
@@ -63,9 +65,9 @@ jobs:
     - name: Install BATS
       run: |
         sudo apt-get update
-        sudo apt-get install -y bats
+        sudo apt-get install -y bats parallel
 
     - name: Run Docker entrypoint integration tests
       run: |
         cd services/api/test
-        bats test-docker-entrypoint.bats
+        bats --jobs 4 test-docker-entrypoint.bats

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -48,3 +48,24 @@ jobs:
         # Severity: error,warning (excluding info and style for now)
         find . -name "*.sh" -type f -exec shellcheck --severity=warning {} +
         shellcheck --severity=warning scripts/git-hooks/pre-commit scripts/git-hooks/commit-msg
+
+  docker-entrypoint-tests:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Install BATS
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bats
+
+    - name: Run Docker entrypoint integration tests
+      run: |
+        cd services/api/test
+        bats test-docker-entrypoint.bats

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -325,7 +325,7 @@ sudo apt-get install bats
 cd services/api/test
 bats test-docker-entrypoint.bats
 
-# Run in parallel (faster for larger test suites)
+# Run in parallel (requires: brew install parallel on macOS)
 bats --jobs 4 test-docker-entrypoint.bats
 ```
 

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -307,6 +307,40 @@ Coverage report generated at: `target/scala-2.13/scoverage-report/index.html`
 - API: `src/test/scala/skatemap/api/`
 - Integration: `src/test/scala/skatemap/integration/`
 
+### Docker Entrypoint Tests
+
+Integration tests for `docker-entrypoint.sh` verify container startup behaviour using BATS (Bash Automated Testing System).
+
+**Install BATS:**
+```bash
+# macOS
+brew install bats-core
+
+# Ubuntu/Debian
+sudo apt-get install bats
+```
+
+**Run tests:**
+```bash
+cd services/api/test
+bats test-docker-entrypoint.bats
+```
+
+**Requirements:**
+- BATS testing framework
+- Docker daemon running
+- Docker BuildKit enabled (default on modern installations)
+
+**Test scenarios:**
+1. Entrypoint exits with error when APPLICATION_SECRET is missing
+2. Entrypoint starts application with OpenTelemetry agent present
+3. Entrypoint starts application without OpenTelemetry agent (graceful degradation)
+4. Entrypoint logs OTEL configuration in debug mode
+
+**Note:** Health check endpoint functionality is verified by smoke tests in `tools/load-testing/test/`.
+
+**Duration:** ~30 seconds (includes Docker builds and container startup)
+
 ## Troubleshooting
 
 ### "Route not found" or 404 errors

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -324,6 +324,9 @@ sudo apt-get install bats
 ```bash
 cd services/api/test
 bats test-docker-entrypoint.bats
+
+# Run in parallel (faster for larger test suites)
+bats --jobs 4 test-docker-entrypoint.bats
 ```
 
 **Requirements:**

--- a/services/api/test/test-docker-entrypoint.bats
+++ b/services/api/test/test-docker-entrypoint.bats
@@ -4,12 +4,14 @@ OTEL_AGENT_JAR="/app/opentelemetry-javaagent.jar"
 
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
-  TEST_LABEL="test=docker-entrypoint-$$"
+  TEST_RUN_ID="$$-$RANDOM"
+  TEST_LABEL="test=docker-entrypoint-$TEST_RUN_ID"
+  IMAGE_PREFIX="skatemap-test-$TEST_RUN_ID"
 }
 
 teardown() {
   docker ps -aq -f "label=$TEST_LABEL" | xargs -r docker rm -f >/dev/null 2>&1 || true
-  docker images -q "skatemap-test:*" | xargs -r docker rmi -f >/dev/null 2>&1 || true
+  docker images -q "$IMAGE_PREFIX:*" | xargs -r docker rmi -f >/dev/null 2>&1 || true
 }
 
 build_test_image() {
@@ -18,7 +20,7 @@ build_test_image() {
   local dockerfile="$BATS_TEST_DIRNAME/Dockerfile.$image_name"
 
   printf '%s\n' "$dockerfile_content" >"$dockerfile"
-  docker build -f "$dockerfile" -t "skatemap-test:$image_name" "$REPO_ROOT" >/dev/null 2>&1
+  docker build -f "$dockerfile" -t "$IMAGE_PREFIX:$image_name" "$REPO_ROOT" >/dev/null 2>&1
   local build_result=$?
   rm -f "$dockerfile"
   return $build_result
@@ -27,7 +29,7 @@ build_test_image() {
 run_container() {
   local image="$1"
   shift
-  docker run -d --label "$TEST_LABEL" "$@" "skatemap-test:$image"
+  docker run -d --label "$TEST_LABEL" "$@" "$IMAGE_PREFIX:$image"
 }
 
 base_dockerfile() {
@@ -71,7 +73,7 @@ RUN echo '#!/bin/sh' > bin/skatemap-live && chmod +x bin/skatemap-live
 $(entrypoint_setup)"
 
   build_test_image "no-secret" "$dockerfile"
-  run sh -c "docker run --rm --label $TEST_LABEL skatemap-test:no-secret 2>&1; exit \$?"
+  run sh -c "docker run --rm --label $TEST_LABEL $IMAGE_PREFIX:no-secret 2>&1; exit \$?"
 
   [[ "$output" =~ "ERROR: APPLICATION_SECRET environment variable is required" ]] ||
     fail "Expected error message not found in output: $output"

--- a/services/api/test/test-docker-entrypoint.bats
+++ b/services/api/test/test-docker-entrypoint.bats
@@ -20,10 +20,14 @@ build_test_image() {
   local dockerfile="$BATS_TEST_DIRNAME/Dockerfile.$image_name"
 
   printf '%s\n' "$dockerfile_content" >"$dockerfile"
-  docker build -f "$dockerfile" -t "$IMAGE_PREFIX:$image_name" "$REPO_ROOT" >/dev/null 2>&1
-  local build_result=$?
-  rm -f "$dockerfile"
-  return $build_result
+  trap 'rm -f "$dockerfile"' RETURN
+
+  local build_output
+  if ! build_output=$(docker build -f "$dockerfile" -t "$IMAGE_PREFIX:$image_name" "$REPO_ROOT" 2>&1); then
+    echo "Docker build failed for $image_name:" >&2
+    echo "$build_output" >&2
+    return 1
+  fi
 }
 
 run_container() {
@@ -112,7 +116,7 @@ $(entrypoint_setup)"
   run sh -c "docker logs $container_id 2>&1"
   docker rm -f "$container_id" >/dev/null 2>&1
 
-  [[ "$output" =~ "WARNING: OpenTelemetry agent not found at $OTEL_AGENT_JAR" ]] ||
+  [[ "$output" =~ WARNING:\ OpenTelemetry\ agent\ not\ found\ at\ $OTEL_AGENT_JAR ]] ||
     fail "Expected warning about missing OTEL agent not found. Output: $output"
   [[ "$output" =~ "Application started" ]] ||
     fail "Application failed to start without OTEL agent. Output: $output"
@@ -138,11 +142,11 @@ $(entrypoint_setup)"
 
   [[ "$output" =~ "DEBUG: OTEL configuration:" ]] ||
     fail "Debug header not found. Output: $output"
-  [[ "$output" =~ "Agent: $OTEL_AGENT_JAR" ]] ||
+  [[ "$output" =~ Agent:\ $OTEL_AGENT_JAR ]] ||
     fail "Agent path not logged. Output: $output"
   [[ "$output" =~ "Service: test-service" ]] ||
     fail "Service name not logged. Output: $output"
-  [[ "$output" =~ "Endpoint: https://api.honeycomb.io" ]] ||
+  [[ "$output" =~ Endpoint:\ https://api\.honeycomb\.io ]] ||
     fail "Endpoint not logged. Output: $output"
   [[ "$output" =~ "Protocol: http/protobuf" ]] ||
     fail "Protocol not logged. Output: $output"

--- a/services/api/test/test-docker-entrypoint.bats
+++ b/services/api/test/test-docker-entrypoint.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  TEST_LABEL="test=docker-entrypoint-$$"
+}
+
+teardown() {
+  docker ps -aq -f "label=$TEST_LABEL" | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker images -q "skatemap-test:*" | xargs -r docker rmi -f >/dev/null 2>&1 || true
+}
+
+build_test_image() {
+  local image_name="$1"
+  local dockerfile_content="$2"
+  local dockerfile="$BATS_TEST_DIRNAME/Dockerfile.$image_name"
+
+  printf '%s\n' "$dockerfile_content" >"$dockerfile"
+  docker build -f "$dockerfile" -t "skatemap-test:$image_name" "$REPO_ROOT" >/dev/null 2>&1
+  local build_result=$?
+  rm -f "$dockerfile"
+  return $build_result
+}
+
+run_container() {
+  local image="$1"
+  shift
+  docker run -d --label "$TEST_LABEL" "$@" "skatemap-test:$image"
+}
+
+@test "entrypoint exits with error when APPLICATION_SECRET is missing" {
+  build_test_image "no-secret" 'FROM eclipse-temurin:21-jre
+WORKDIR /app
+RUN mkdir -p bin
+RUN echo "#!/bin/sh" > bin/skatemap-live && chmod +x bin/skatemap-live
+COPY services/api/docker-entrypoint.sh /app/
+RUN chmod +x /app/docker-entrypoint.sh
+ENTRYPOINT ["/app/docker-entrypoint.sh"]'
+
+  run sh -c "docker run --rm --label $TEST_LABEL skatemap-test:no-secret 2>&1; exit \$?"
+
+  [[ "$output" =~ "ERROR: APPLICATION_SECRET environment variable is required" ]]
+  [ "$status" -eq 1 ]
+}
+
+@test "entrypoint starts application with OpenTelemetry agent present" {
+  build_test_image "with-agent" 'FROM eclipse-temurin:21-jre
+WORKDIR /app
+RUN mkdir -p bin
+RUN echo "#!/bin/sh" > bin/skatemap-live && \
+    echo "echo Application started" >> bin/skatemap-live && \
+    echo "sleep 2" >> bin/skatemap-live && \
+    chmod +x bin/skatemap-live
+RUN echo "mock-otel-agent-jar" > /app/opentelemetry-javaagent.jar
+COPY services/api/docker-entrypoint.sh /app/
+RUN chmod +x /app/docker-entrypoint.sh
+ENTRYPOINT ["/app/docker-entrypoint.sh"]'
+
+  container_id=$(run_container "with-agent" -e APPLICATION_SECRET="test-secret")
+  sleep 3
+  run sh -c "docker logs $container_id 2>&1"
+  docker rm -f "$container_id" >/dev/null 2>&1
+
+  [[ "$output" =~ "Application started" ]]
+  [[ ! "$output" =~ "WARNING: OpenTelemetry agent not found" ]]
+}
+
+@test "entrypoint starts application without OpenTelemetry agent" {
+  build_test_image "no-agent" 'FROM eclipse-temurin:21-jre
+WORKDIR /app
+RUN mkdir -p bin
+RUN echo "#!/bin/sh" > bin/skatemap-live && \
+    echo "echo Application started" >> bin/skatemap-live && \
+    echo "sleep 2" >> bin/skatemap-live && \
+    chmod +x bin/skatemap-live
+COPY services/api/docker-entrypoint.sh /app/
+RUN chmod +x /app/docker-entrypoint.sh
+ENTRYPOINT ["/app/docker-entrypoint.sh"]'
+
+  container_id=$(run_container "no-agent" -e APPLICATION_SECRET="test-secret")
+  sleep 3
+  run sh -c "docker logs $container_id 2>&1"
+  docker rm -f "$container_id" >/dev/null 2>&1
+
+  [[ "$output" =~ "WARNING: OpenTelemetry agent not found at /app/opentelemetry-javaagent.jar" ]]
+  [[ "$output" =~ "Application started" ]]
+}
+
+@test "entrypoint logs OTEL configuration in debug mode" {
+  build_test_image "debug" 'FROM eclipse-temurin:21-jre
+WORKDIR /app
+RUN mkdir -p bin
+RUN echo "#!/bin/sh" > bin/skatemap-live && \
+    echo "sleep 2" >> bin/skatemap-live && \
+    chmod +x bin/skatemap-live
+RUN echo "mock-otel-agent-jar" > /app/opentelemetry-javaagent.jar
+COPY services/api/docker-entrypoint.sh /app/
+RUN chmod +x /app/docker-entrypoint.sh
+ENTRYPOINT ["/app/docker-entrypoint.sh"]'
+
+  container_id=$(run_container "debug" \
+    -e APPLICATION_SECRET="test-secret" \
+    -e DEBUG="1" \
+    -e OTEL_SERVICE_NAME="test-service" \
+    -e OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io" \
+    -e OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf")
+  sleep 3
+  run sh -c "docker logs $container_id 2>&1"
+  docker rm -f "$container_id" >/dev/null 2>&1
+
+  [[ "$output" =~ "DEBUG: OTEL configuration:" ]]
+  [[ "$output" =~ "Agent: /app/opentelemetry-javaagent.jar" ]]
+  [[ "$output" =~ "Service: test-service" ]]
+  [[ "$output" =~ "Endpoint: https://api.honeycomb.io" ]]
+  [[ "$output" =~ "Protocol: http/protobuf" ]]
+}
+

--- a/services/api/test/test-docker-entrypoint.bats
+++ b/services/api/test/test-docker-entrypoint.bats
@@ -114,4 +114,3 @@ ENTRYPOINT ["/app/docker-entrypoint.sh"]'
   [[ "$output" =~ "Endpoint: https://api.honeycomb.io" ]]
   [[ "$output" =~ "Protocol: http/protobuf" ]]
 }
-

--- a/services/api/test/test-docker-entrypoint.bats
+++ b/services/api/test/test-docker-entrypoint.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+OTEL_AGENT_JAR="/app/opentelemetry-javaagent.jar"
+
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
   TEST_LABEL="test=docker-entrypoint-$$"
@@ -28,76 +30,100 @@ run_container() {
   docker run -d --label "$TEST_LABEL" "$@" "skatemap-test:$image"
 }
 
-@test "entrypoint exits with error when APPLICATION_SECRET is missing" {
-  build_test_image "no-secret" 'FROM eclipse-temurin:21-jre
+base_dockerfile() {
+  cat <<'EOF'
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 RUN mkdir -p bin
-RUN echo "#!/bin/sh" > bin/skatemap-live && chmod +x bin/skatemap-live
-COPY services/api/docker-entrypoint.sh /app/
-RUN chmod +x /app/docker-entrypoint.sh
-ENTRYPOINT ["/app/docker-entrypoint.sh"]'
-
-  run sh -c "docker run --rm --label $TEST_LABEL skatemap-test:no-secret 2>&1; exit \$?"
-
-  [[ "$output" =~ "ERROR: APPLICATION_SECRET environment variable is required" ]]
-  [ "$status" -eq 1 ]
+EOF
 }
 
-@test "entrypoint starts application with OpenTelemetry agent present" {
-  build_test_image "with-agent" 'FROM eclipse-temurin:21-jre
-WORKDIR /app
-RUN mkdir -p bin
+mock_app_script() {
+  local include_output="${1:-false}"
+  if [ "$include_output" = "true" ]; then
+    cat <<'EOF'
 RUN echo "#!/bin/sh" > bin/skatemap-live && \
     echo "echo Application started" >> bin/skatemap-live && \
     echo "sleep 2" >> bin/skatemap-live && \
     chmod +x bin/skatemap-live
-RUN echo "mock-otel-agent-jar" > /app/opentelemetry-javaagent.jar
+EOF
+  else
+    cat <<'EOF'
+RUN echo "#!/bin/sh" > bin/skatemap-live && \
+    echo "sleep 2" >> bin/skatemap-live && \
+    chmod +x bin/skatemap-live
+EOF
+  fi
+}
+
+entrypoint_setup() {
+  cat <<'EOF'
 COPY services/api/docker-entrypoint.sh /app/
 RUN chmod +x /app/docker-entrypoint.sh
-ENTRYPOINT ["/app/docker-entrypoint.sh"]'
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+EOF
+}
 
+@test "entrypoint exits with error when APPLICATION_SECRET is missing" {
+  local dockerfile
+  dockerfile="$(base_dockerfile)
+RUN echo '#!/bin/sh' > bin/skatemap-live && chmod +x bin/skatemap-live
+$(entrypoint_setup)"
+
+  build_test_image "no-secret" "$dockerfile"
+  run sh -c "docker run --rm --label $TEST_LABEL skatemap-test:no-secret 2>&1; exit \$?"
+
+  [[ "$output" =~ "ERROR: APPLICATION_SECRET environment variable is required" ]] ||
+    fail "Expected error message not found in output: $output"
+  [ "$status" -eq 1 ] ||
+    fail "Expected exit code 1, got: $status"
+}
+
+@test "entrypoint starts application with OpenTelemetry agent present" {
+  local dockerfile
+  dockerfile="$(base_dockerfile)
+$(mock_app_script true)
+RUN echo 'mock-otel-agent-jar' > $OTEL_AGENT_JAR
+$(entrypoint_setup)"
+
+  build_test_image "with-agent" "$dockerfile"
   container_id=$(run_container "with-agent" -e APPLICATION_SECRET="test-secret")
   sleep 3
   run sh -c "docker logs $container_id 2>&1"
   docker rm -f "$container_id" >/dev/null 2>&1
 
-  [[ "$output" =~ "Application started" ]]
-  [[ ! "$output" =~ "WARNING: OpenTelemetry agent not found" ]]
+  [[ "$output" =~ "Application started" ]] ||
+    fail "Application failed to start. Output: $output"
+  [[ ! "$output" =~ "WARNING: OpenTelemetry agent not found" ]] ||
+    fail "Unexpected warning about missing OTEL agent. Output: $output"
 }
 
 @test "entrypoint starts application without OpenTelemetry agent" {
-  build_test_image "no-agent" 'FROM eclipse-temurin:21-jre
-WORKDIR /app
-RUN mkdir -p bin
-RUN echo "#!/bin/sh" > bin/skatemap-live && \
-    echo "echo Application started" >> bin/skatemap-live && \
-    echo "sleep 2" >> bin/skatemap-live && \
-    chmod +x bin/skatemap-live
-COPY services/api/docker-entrypoint.sh /app/
-RUN chmod +x /app/docker-entrypoint.sh
-ENTRYPOINT ["/app/docker-entrypoint.sh"]'
+  local dockerfile
+  dockerfile="$(base_dockerfile)
+$(mock_app_script true)
+$(entrypoint_setup)"
 
+  build_test_image "no-agent" "$dockerfile"
   container_id=$(run_container "no-agent" -e APPLICATION_SECRET="test-secret")
   sleep 3
   run sh -c "docker logs $container_id 2>&1"
   docker rm -f "$container_id" >/dev/null 2>&1
 
-  [[ "$output" =~ "WARNING: OpenTelemetry agent not found at /app/opentelemetry-javaagent.jar" ]]
-  [[ "$output" =~ "Application started" ]]
+  [[ "$output" =~ "WARNING: OpenTelemetry agent not found at $OTEL_AGENT_JAR" ]] ||
+    fail "Expected warning about missing OTEL agent not found. Output: $output"
+  [[ "$output" =~ "Application started" ]] ||
+    fail "Application failed to start without OTEL agent. Output: $output"
 }
 
 @test "entrypoint logs OTEL configuration in debug mode" {
-  build_test_image "debug" 'FROM eclipse-temurin:21-jre
-WORKDIR /app
-RUN mkdir -p bin
-RUN echo "#!/bin/sh" > bin/skatemap-live && \
-    echo "sleep 2" >> bin/skatemap-live && \
-    chmod +x bin/skatemap-live
-RUN echo "mock-otel-agent-jar" > /app/opentelemetry-javaagent.jar
-COPY services/api/docker-entrypoint.sh /app/
-RUN chmod +x /app/docker-entrypoint.sh
-ENTRYPOINT ["/app/docker-entrypoint.sh"]'
+  local dockerfile
+  dockerfile="$(base_dockerfile)
+$(mock_app_script false)
+RUN echo 'mock-otel-agent-jar' > $OTEL_AGENT_JAR
+$(entrypoint_setup)"
 
+  build_test_image "debug" "$dockerfile"
   container_id=$(run_container "debug" \
     -e APPLICATION_SECRET="test-secret" \
     -e DEBUG="1" \
@@ -108,9 +134,14 @@ ENTRYPOINT ["/app/docker-entrypoint.sh"]'
   run sh -c "docker logs $container_id 2>&1"
   docker rm -f "$container_id" >/dev/null 2>&1
 
-  [[ "$output" =~ "DEBUG: OTEL configuration:" ]]
-  [[ "$output" =~ "Agent: /app/opentelemetry-javaagent.jar" ]]
-  [[ "$output" =~ "Service: test-service" ]]
-  [[ "$output" =~ "Endpoint: https://api.honeycomb.io" ]]
-  [[ "$output" =~ "Protocol: http/protobuf" ]]
+  [[ "$output" =~ "DEBUG: OTEL configuration:" ]] ||
+    fail "Debug header not found. Output: $output"
+  [[ "$output" =~ "Agent: $OTEL_AGENT_JAR" ]] ||
+    fail "Agent path not logged. Output: $output"
+  [[ "$output" =~ "Service: test-service" ]] ||
+    fail "Service name not logged. Output: $output"
+  [[ "$output" =~ "Endpoint: https://api.honeycomb.io" ]] ||
+    fail "Endpoint not logged. Output: $output"
+  [[ "$output" =~ "Protocol: http/protobuf" ]] ||
+    fail "Protocol not logged. Output: $output"
 }


### PR DESCRIPTION
## Summary

Add automated integration tests for `docker-entrypoint.sh` using the BATS (Bash Automated Testing System) framework.

## Changes

- **services/api/test/test-docker-entrypoint.bats** - BATS test suite with 4 integration tests
- **.github/workflows/shell.yml** - Added BATS installation and test execution to CI
- **services/api/README.md** - Documentation for running BATS tests locally

## Test Coverage

✅ Entrypoint exits with error when APPLICATION_SECRET is missing  
✅ Entrypoint starts application with OpenTelemetry agent present  
✅ Entrypoint starts without agent (graceful degradation)  
✅ Entrypoint logs OTEL configuration in debug mode

## Design Decisions

- **BATS framework**: Standard shell testing tool, follows established patterns
- **DRY helpers**: `build_test_image()`, `run_container()` reduce duplication
- **Docker-based**: Tests actual container behaviour, not just parameter expansion
- **Mock containers**: Fast tests using minimal Docker images (~30 seconds total)
- **Scope**: Health check functionality verified separately by existing smoke tests

## Testing

Locally:
\`\`\`bash
brew install bats-core
cd services/api/test
bats test-docker-entrypoint.bats
\`\`\`

CI: Runs automatically via `.github/workflows/shell.yml`

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Docker-based integration tests and a CI job; main risk is increased CI flakiness/time due to Docker builds and container startup.
> 
> **Overview**
> Adds Docker-based BATS integration coverage for `services/api/docker-entrypoint.sh`, validating required `APPLICATION_SECRET`, OpenTelemetry agent present/missing behavior, and OTEL debug logging.
> 
> Updates CI (`.github/workflows/shell.yml`) to run these `.bats` tests on PRs/pushes (installing `bats` + `parallel` and executing `bats --jobs 4`), and documents local execution/requirements in `services/api/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6413c8e214e1f31f3ca8db2f162e15588859dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->