### PR TITLE
feat: add shellcheck linting to pre-commit hook and CI

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -10,6 +10,7 @@ on:
       - '**/*.bats'
       - 'scripts/git-hooks/**'
       - '.github/workflows/shell.yml'
+      - '.shellcheckrc'
   pull_request:
     branches: [ master ]
     paths:
@@ -17,6 +18,7 @@ on:
       - '**/*.bats'
       - 'scripts/git-hooks/**'
       - '.github/workflows/shell.yml'
+      - '.shellcheckrc'
 
 jobs:
   quality:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -46,11 +46,10 @@ jobs:
     - name: Lint shell scripts
       run: |
         echo "Linting shell scripts..."
-        # Note: SC1091 (can't follow source) is acceptable - test scripts source files dynamically
-        # Severity: error,warning (excluding info and style for now)
-        find . -name "*.sh" -type f -exec shellcheck --severity=warning {} +
-        find . -name "*.bats" -type f -exec shellcheck --severity=warning {} +
-        shellcheck --severity=warning scripts/git-hooks/pre-commit scripts/git-hooks/commit-msg
+        # Configuration in .shellcheckrc
+        find . -name "*.sh" -type f -exec shellcheck {} +
+        find . -name "*.bats" -type f -exec shellcheck {} +
+        shellcheck scripts/git-hooks/pre-commit scripts/git-hooks/commit-msg
 
   docker-entrypoint-tests:
 

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -46,10 +46,10 @@ jobs:
     - name: Lint shell scripts
       run: |
         echo "Linting shell scripts..."
-        # Configuration in .shellcheckrc
-        find . -name "*.sh" -type f -exec shellcheck {} +
-        find . -name "*.bats" -type f -exec shellcheck {} +
-        shellcheck scripts/git-hooks/pre-commit scripts/git-hooks/commit-msg
+        # .shellcheckrc handles disable rules, severity must be CLI flag
+        find . -name "*.sh" -type f -exec shellcheck --severity=warning {} +
+        find . -name "*.bats" -type f -exec shellcheck --severity=warning {} +
+        shellcheck --severity=warning scripts/git-hooks/pre-commit scripts/git-hooks/commit-msg
 
   docker-entrypoint-tests:
 

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -49,9 +49,10 @@ jobs:
       run: |
         echo "Linting shell scripts..."
         # .shellcheckrc handles disable rules, severity must be CLI flag
-        find . -name "*.sh" -type f -exec shellcheck --severity=warning {} +
-        find . -name "*.bats" -type f -exec shellcheck --severity=warning {} +
-        shellcheck --severity=warning scripts/git-hooks/pre-commit scripts/git-hooks/commit-msg
+        # --format=gcc provides file:line:col output for easier debugging
+        find . -name "*.sh" -type f -exec shellcheck --severity=warning --format=gcc {} +
+        find . -name "*.bats" -type f -exec shellcheck --severity=warning --format=gcc {} +
+        shellcheck --severity=warning --format=gcc scripts/git-hooks/pre-commit scripts/git-hooks/commit-msg
 
   docker-entrypoint-tests:
 

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -49,6 +49,7 @@ jobs:
         # Note: SC1091 (can't follow source) is acceptable - test scripts source files dynamically
         # Severity: error,warning (excluding info and style for now)
         find . -name "*.sh" -type f -exec shellcheck --severity=warning {} +
+        find . -name "*.bats" -type f -exec shellcheck --severity=warning {} +
         shellcheck --severity=warning scripts/git-hooks/pre-commit scripts/git-hooks/commit-msg
 
   docker-entrypoint-tests:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,13 +1,9 @@
 # shellcheck configuration
 # See https://github.com/koalaman/shellcheck/wiki/SC1091
 
-# Set minimum severity level (error, warning, info, style)
-severity=warning
-
 # Ignore rules
 # SC1091: Can't follow source - test scripts source files dynamically
 disable=SC1091
 
-# Show 3 lines of context around issues for better debugging
-# Note: Only used in CI, not in pre-commit hook
-# format=gcc
+# Note: severity is a CLI flag, not an rc file directive
+# Use --severity=warning on command line instead

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,9 @@
+# shellcheck configuration
+# See https://github.com/koalaman/shellcheck/wiki/SC1091
+
+# Set minimum severity level (error, warning, info, style)
+severity=warning
+
+# Ignore rules
+# SC1091: Can't follow source - test scripts source files dynamically
+disable=SC1091

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -7,3 +7,7 @@ severity=warning
 # Ignore rules
 # SC1091: Can't follow source - test scripts source files dynamically
 disable=SC1091
+
+# Show 3 lines of context around issues for better debugging
+# Note: Only used in CI, not in pre-commit hook
+# format=gcc

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -144,7 +144,7 @@ if [ -n "$staged_sh_files" ] || [ -n "$staged_bats_files" ]; then
   shellcheck_failed=false
   for file in $staged_sh_files $staged_bats_files; do
     if [ -f "$file" ]; then
-      if ! shellcheck --severity=warning "$file"; then
+      if ! shellcheck --severity=warning --format=gcc "$file"; then
         shellcheck_failed=true
       fi
     fi

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -8,10 +8,11 @@ set -e
 # Check if there are any staged Scala, Go, or shell files
 staged_scala_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.scala$' || true)
 staged_go_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
-staged_sh_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(sh|bats)$' || true)
+staged_sh_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.sh$' || true)
+staged_bats_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.bats$' || true)
 
 # Exit early only if no Scala, Go, or shell files are staged
-if [ -z "$staged_scala_files" ] && [ -z "$staged_go_files" ] && [ -z "$staged_sh_files" ]; then
+if [ -z "$staged_scala_files" ] && [ -z "$staged_go_files" ] && [ -z "$staged_sh_files" ] && [ -z "$staged_bats_files" ]; then
   exit 0
 fi
 
@@ -129,8 +130,8 @@ if [ -n "$staged_sh_files" ]; then
   echo "Pre-commit shfmt check completed successfully."
 fi
 
-# Lint shell files if any are staged
-if [ -n "$staged_sh_files" ]; then
+# Lint shell and BATS files if any are staged
+if [ -n "$staged_sh_files" ] || [ -n "$staged_bats_files" ]; then
   echo "Running shellcheck on staged shell files..."
 
   if ! command -v shellcheck &>/dev/null; then
@@ -141,7 +142,7 @@ if [ -n "$staged_sh_files" ]; then
   fi
 
   shellcheck_failed=false
-  for file in $staged_sh_files; do
+  for file in $staged_sh_files $staged_bats_files; do
     if [ -f "$file" ]; then
       if ! shellcheck --severity=warning "$file"; then
         shellcheck_failed=true

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -8,7 +8,7 @@ set -e
 # Check if there are any staged Scala, Go, or shell files
 staged_scala_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.scala$' || true)
 staged_go_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
-staged_sh_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.sh$' || true)
+staged_sh_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(sh|bats)$' || true)
 
 # Exit early only if no Scala, Go, or shell files are staged
 if [ -z "$staged_scala_files" ] && [ -z "$staged_go_files" ] && [ -z "$staged_sh_files" ]; then
@@ -127,6 +127,35 @@ if [ -n "$staged_sh_files" ]; then
   fi
 
   echo "Pre-commit shfmt check completed successfully."
+fi
+
+# Lint shell files if any are staged
+if [ -n "$staged_sh_files" ]; then
+  echo "Running shellcheck on staged shell files..."
+
+  if ! command -v shellcheck &>/dev/null; then
+    echo "Error: shellcheck not found in PATH"
+    echo "Install with: brew install shellcheck"
+    echo "Or on Linux: sudo apt-get install shellcheck"
+    exit 1
+  fi
+
+  shellcheck_failed=false
+  for file in $staged_sh_files; do
+    if [ -f "$file" ]; then
+      if ! shellcheck --severity=warning "$file"; then
+        shellcheck_failed=true
+      fi
+    fi
+  done
+
+  if [ "$shellcheck_failed" = true ]; then
+    echo "Error: shellcheck found issues in staged shell files" >&2
+    echo "Fix the issues above and commit again" >&2
+    exit 1
+  fi
+
+  echo "Pre-commit shellcheck completed successfully."
 fi
 
 exit 0

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -143,7 +143,7 @@ if [ -n "$staged_sh_files" ]; then
   shellcheck_failed=false
   for file in $staged_sh_files; do
     if [ -f "$file" ]; then
-      if ! shellcheck "$file"; then
+      if ! shellcheck --severity=warning "$file"; then
         shellcheck_failed=true
       fi
     fi

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -140,8 +140,16 @@ if [ -n "$staged_sh_files" ]; then
     exit 1
   fi
 
-  # shellcheck disable=SC2086
-  if ! shellcheck $staged_sh_files; then
+  shellcheck_failed=false
+  for file in $staged_sh_files; do
+    if [ -f "$file" ]; then
+      if ! shellcheck "$file"; then
+        shellcheck_failed=true
+      fi
+    fi
+  done
+
+  if [ "$shellcheck_failed" = true ]; then
     echo "Error: shellcheck found issues in staged shell files" >&2
     echo "Fix the issues above and commit again" >&2
     exit 1

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -140,16 +140,8 @@ if [ -n "$staged_sh_files" ]; then
     exit 1
   fi
 
-  shellcheck_failed=false
-  for file in $staged_sh_files; do
-    if [ -f "$file" ]; then
-      if ! shellcheck --severity=warning "$file"; then
-        shellcheck_failed=true
-      fi
-    fi
-  done
-
-  if [ "$shellcheck_failed" = true ]; then
+  # shellcheck disable=SC2086
+  if ! shellcheck $staged_sh_files; then
     echo "Error: shellcheck found issues in staged shell files" >&2
     echo "Fix the issues above and commit again" >&2
     exit 1

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -97,8 +97,8 @@ if [ -n "$staged_go_files" ]; then
   echo "Pre-commit goimports check completed successfully."
 fi
 
-# Format shell files if any are staged
-if [ -n "$staged_sh_files" ]; then
+# Format shell and BATS files if any are staged
+if [ -n "$staged_sh_files" ] || [ -n "$staged_bats_files" ]; then
   echo "Running shfmt on staged shell files..."
 
   if ! command -v shfmt &>/dev/null; then
@@ -108,14 +108,14 @@ if [ -n "$staged_sh_files" ]; then
     exit 1
   fi
 
-  for file in $staged_sh_files; do
+  for file in $staged_sh_files $staged_bats_files; do
     if [ -f "$file" ]; then
       shfmt -i 2 -w "$file"
     fi
   done
 
   sh_changes_made=false
-  for file in $staged_sh_files; do
+  for file in $staged_sh_files $staged_bats_files; do
     if git diff --name-only | grep -q "^$file$"; then
       sh_changes_made=true
       echo "Formatted: $file"


### PR DESCRIPTION
## Summary

Add shellcheck linting for both `.sh` and `.bats` files to catch bugs before commit instead of discovering them in CI or code review.

## Changes

- **Pre-commit hook**: Runs shellcheck after shfmt formatting
- **File detection**: Detects and lints `.bats` files in addition to `.sh` files  
- **CI workflow**: Updated to lint `.bats` files with shellcheck
- **Error handling**: Shellcheck failures block commits until issues are resolved

## Motivation

This would have caught the shellcheck warnings in PR #219 before commit, saving review cycles. Catching bugs earlier in the development workflow improves code quality and reduces friction.

## Testing

**Local test:**
```bash
# Stage a shell file with shellcheck warnings
echo '#!/bin/bash\necho $foo' > test.sh
git add test.sh
git commit -m "test"
# Should fail with shellcheck warning about unquoted variable
```

**CI test:** Will run on this PR

Addresses task #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and developer-workflow tooling changes only; main risk is increased commit/CI failures due to stricter linting or new `.bats` coverage.
> 
> **Overview**
> Adds ShellCheck enforcement across the repo by introducing a `.shellcheckrc` (disabling `SC1091`) and wiring it into the shell quality GitHub Action triggers.
> 
> Updates CI to lint both `.sh` and `.bats` files (plus git hooks) with `shellcheck --severity=warning --format=gcc` for consistent, debuggable output.
> 
> Extends the `pre-commit` hook to detect staged `.bats` files, run `shfmt` on both `.sh` and `.bats`, and **block commits** when `shellcheck` reports warnings/errors on staged scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fcaa679b95949643555bc6568952f7827cbb9cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->