### PR TITLE
test: add automated validation for Railway configuration

### DIFF
--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -4,6 +4,30 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+validate_path() {
+  local path="$1"
+  local description="$2"
+
+  if [[ "$path" =~ \.\. ]]; then
+    echo "ERROR: Invalid $description path (contains ..): $path"
+    exit 1
+  fi
+
+  if [[ "$path" =~ ^/ ]] && [[ "$description" != "start command" ]]; then
+    echo "ERROR: Invalid $description path (absolute path not allowed): $path"
+    exit 1
+  fi
+}
+
+extract_toml_value() {
+  local key="$1"
+  local file="$2"
+  set +e
+  local value=$(grep -E "^\s*${key}\s*=" "$file" | sed -E 's/.*= "(.*)".*/\1/')
+  set -e
+  echo "$value"
+}
+
 echo "Validating railway.toml configuration..."
 
 if [[ ! -f railway.toml ]]; then
@@ -11,11 +35,13 @@ if [[ ! -f railway.toml ]]; then
   exit 1
 fi
 
-DOCKERFILE_PATH=$(grep -E '^\s*dockerfilePath\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/' || true)
+DOCKERFILE_PATH=$(extract_toml_value "dockerfilePath" "railway.toml")
 if [[ -z "$DOCKERFILE_PATH" ]]; then
   echo "ERROR: dockerfilePath not found in railway.toml"
   exit 1
 fi
+
+validate_path "$DOCKERFILE_PATH" "dockerfile"
 
 if [[ ! -f "$DOCKERFILE_PATH" ]]; then
   echo "ERROR: Dockerfile not found at $DOCKERFILE_PATH"
@@ -23,7 +49,7 @@ if [[ ! -f "$DOCKERFILE_PATH" ]]; then
 fi
 echo "✓ Dockerfile exists: $DOCKERFILE_PATH"
 
-START_COMMAND=$(grep -E '^\s*startCommand\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/' || true)
+START_COMMAND=$(extract_toml_value "startCommand" "railway.toml")
 if [[ -z "$START_COMMAND" ]]; then
   echo "ERROR: startCommand not found in railway.toml"
   exit 1
@@ -31,6 +57,8 @@ fi
 
 if [[ "$START_COMMAND" == "/app/docker-entrypoint.sh" ]]; then
   ENTRYPOINT_SOURCE="services/api/docker-entrypoint.sh"
+  validate_path "$ENTRYPOINT_SOURCE" "entrypoint"
+
   if [[ ! -f "$ENTRYPOINT_SOURCE" ]]; then
     echo "ERROR: Entrypoint script not found at $ENTRYPOINT_SOURCE"
     exit 1
@@ -40,7 +68,7 @@ else
   echo "WARNING: startCommand is $START_COMMAND (not /app/docker-entrypoint.sh)"
 fi
 
-HEALTHCHECK_PATH=$(grep -E '^\s*healthcheckPath\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/' || true)
+HEALTHCHECK_PATH=$(extract_toml_value "healthcheckPath" "railway.toml")
 if [[ -z "$HEALTHCHECK_PATH" ]]; then
   echo "ERROR: healthcheckPath not found in railway.toml"
   exit 1
@@ -52,7 +80,7 @@ if [[ ! -f "$ROUTES_FILE" ]]; then
   exit 1
 fi
 
-if ! grep -qE "GET\s*${HEALTHCHECK_PATH}\s" "$ROUTES_FILE"; then
+if ! grep -qF "GET     ${HEALTHCHECK_PATH} " "$ROUTES_FILE"; then
   echo "ERROR: healthcheckPath $HEALTHCHECK_PATH not found in $ROUTES_FILE"
   exit 1
 fi

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -81,7 +81,7 @@ if [[ ! -f "$ROUTES_FILE" ]]; then
   exit 1
 fi
 
-ESCAPED_PATH=$(echo "$HEALTHCHECK_PATH" | sed 's/[.[\*^$]/\\&/g')
+ESCAPED_PATH=$(echo "$HEALTHCHECK_PATH" | sed 's/[.[\*^$+?(){}|]/\\&/g')
 if ! grep -qE "^GET[[:space:]]+${ESCAPED_PATH}([[:space:]]|$)" "$ROUTES_FILE"; then
   echo "ERROR: healthcheckPath $HEALTHCHECK_PATH not found in $ROUTES_FILE"
   exit 1

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -13,7 +13,7 @@ validate_path() {
     exit 1
   fi
 
-  if [[ "$path" =~ ^/ ]] && [[ "$description" != "start command" ]]; then
+  if [[ "$path" =~ ^/ ]]; then
     echo "ERROR: Invalid $description path (absolute path not allowed): $path"
     exit 1
   fi

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -82,7 +82,7 @@ if [[ ! -f "$ROUTES_FILE" ]]; then
 fi
 
 ESCAPED_PATH=$(echo "$HEALTHCHECK_PATH" | sed 's/[.[\*^$]/\\&/g')
-if ! grep -qE "^GET[[:space:]]+${ESCAPED_PATH}[[:space:]]" "$ROUTES_FILE"; then
+if ! grep -qE "^GET[[:space:]]+${ESCAPED_PATH}[[:space:]]+" "$ROUTES_FILE"; then
   echo "ERROR: healthcheckPath $HEALTHCHECK_PATH not found in $ROUTES_FILE"
   exit 1
 fi

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -23,7 +23,7 @@ extract_toml_value() {
   local key="$1"
   local file="$2"
   set +e
-  local value=$(grep -E "^\s*${key}\s*=" "$file" | sed -E 's/.*= "(.*)".*/\1/')
+  local value=$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$file" | sed -E 's/.*= "(.*)".*/\1/')
   set -e
   echo "$value"
 }

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -11,7 +11,7 @@ if [[ ! -f railway.toml ]]; then
   exit 1
 fi
 
-DOCKERFILE_PATH=$(grep -E '^\s*dockerfilePath\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/')
+DOCKERFILE_PATH=$(grep -E '^\s*dockerfilePath\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/' || true)
 if [[ -z "$DOCKERFILE_PATH" ]]; then
   echo "ERROR: dockerfilePath not found in railway.toml"
   exit 1
@@ -23,7 +23,7 @@ if [[ ! -f "$DOCKERFILE_PATH" ]]; then
 fi
 echo "✓ Dockerfile exists: $DOCKERFILE_PATH"
 
-START_COMMAND=$(grep -E '^\s*startCommand\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/')
+START_COMMAND=$(grep -E '^\s*startCommand\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/' || true)
 if [[ -z "$START_COMMAND" ]]; then
   echo "ERROR: startCommand not found in railway.toml"
   exit 1
@@ -40,7 +40,7 @@ else
   echo "WARNING: startCommand is $START_COMMAND (not /app/docker-entrypoint.sh)"
 fi
 
-HEALTHCHECK_PATH=$(grep -E '^\s*healthcheckPath\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/')
+HEALTHCHECK_PATH=$(grep -E '^\s*healthcheckPath\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/' || true)
 if [[ -z "$HEALTHCHECK_PATH" ]]; then
   echo "ERROR: healthcheckPath not found in railway.toml"
   exit 1
@@ -52,7 +52,7 @@ if [[ ! -f "$ROUTES_FILE" ]]; then
   exit 1
 fi
 
-if ! grep -q "GET\s*${HEALTHCHECK_PATH}\s" "$ROUTES_FILE"; then
+if ! grep -qE "GET\s*${HEALTHCHECK_PATH}\s" "$ROUTES_FILE"; then
   echo "ERROR: healthcheckPath $HEALTHCHECK_PATH not found in $ROUTES_FILE"
   exit 1
 fi

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -22,8 +22,9 @@ validate_path() {
 extract_toml_value() {
   local key="$1"
   local file="$2"
+  local value
   set +e
-  local value=$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$file" | sed -E 's/.*= "(.*)".*/\1/')
+  value=$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$file" | sed -E 's/.*= "(.*)".*/\1/')
   set -e
   echo "$value"
 }

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -82,7 +82,7 @@ if [[ ! -f "$ROUTES_FILE" ]]; then
 fi
 
 ESCAPED_PATH=$(echo "$HEALTHCHECK_PATH" | sed 's/[.[\*^$]/\\&/g')
-if ! grep -qE "^GET[[:space:]]+${ESCAPED_PATH}[[:space:]]+" "$ROUTES_FILE"; then
+if ! grep -qE "^GET[[:space:]]+${ESCAPED_PATH}([[:space:]]|$)" "$ROUTES_FILE"; then
   echo "ERROR: healthcheckPath $HEALTHCHECK_PATH not found in $ROUTES_FILE"
   exit 1
 fi

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -58,7 +58,6 @@ fi
 
 if [[ "$START_COMMAND" == "/app/docker-entrypoint.sh" ]]; then
   ENTRYPOINT_SOURCE="services/api/docker-entrypoint.sh"
-  validate_path "$ENTRYPOINT_SOURCE" "entrypoint"
 
   if [[ ! -f "$ENTRYPOINT_SOURCE" ]]; then
     echo "ERROR: Entrypoint script not found at $ENTRYPOINT_SOURCE"

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -81,7 +81,7 @@ if [[ ! -f "$ROUTES_FILE" ]]; then
   exit 1
 fi
 
-ESCAPED_PATH=$(echo "$HEALTHCHECK_PATH" | sed 's/[.[\*^$+?(){}|]/\\&/g')
+ESCAPED_PATH=$(printf '%s\n' "$HEALTHCHECK_PATH" | sed 's/[][\\.*?+|^$(){}]/\\&/g')
 if ! grep -qE "^GET[[:space:]]+${ESCAPED_PATH}([[:space:]]|$)" "$ROUTES_FILE"; then
   echo "ERROR: healthcheckPath $HEALTHCHECK_PATH not found in $ROUTES_FILE"
   exit 1

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Validating railway.toml configuration..."
+
+if [[ ! -f railway.toml ]]; then
+  echo "ERROR: railway.toml not found"
+  exit 1
+fi
+
+DOCKERFILE_PATH=$(grep -E '^\s*dockerfilePath\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/')
+if [[ -z "$DOCKERFILE_PATH" ]]; then
+  echo "ERROR: dockerfilePath not found in railway.toml"
+  exit 1
+fi
+
+if [[ ! -f "$DOCKERFILE_PATH" ]]; then
+  echo "ERROR: Dockerfile not found at $DOCKERFILE_PATH"
+  exit 1
+fi
+echo "✓ Dockerfile exists: $DOCKERFILE_PATH"
+
+START_COMMAND=$(grep -E '^\s*startCommand\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/')
+if [[ -z "$START_COMMAND" ]]; then
+  echo "ERROR: startCommand not found in railway.toml"
+  exit 1
+fi
+
+if [[ "$START_COMMAND" == "/app/docker-entrypoint.sh" ]]; then
+  ENTRYPOINT_SOURCE="services/api/docker-entrypoint.sh"
+  if [[ ! -f "$ENTRYPOINT_SOURCE" ]]; then
+    echo "ERROR: Entrypoint script not found at $ENTRYPOINT_SOURCE"
+    exit 1
+  fi
+  echo "✓ Entrypoint script exists: $ENTRYPOINT_SOURCE"
+else
+  echo "WARNING: startCommand is $START_COMMAND (not /app/docker-entrypoint.sh)"
+fi
+
+HEALTHCHECK_PATH=$(grep -E '^\s*healthcheckPath\s*=' railway.toml | sed -E 's/.*= "(.*)".*/\1/')
+if [[ -z "$HEALTHCHECK_PATH" ]]; then
+  echo "ERROR: healthcheckPath not found in railway.toml"
+  exit 1
+fi
+
+ROUTES_FILE="services/api/src/main/resources/routes"
+if [[ ! -f "$ROUTES_FILE" ]]; then
+  echo "ERROR: Routes file not found at $ROUTES_FILE"
+  exit 1
+fi
+
+if ! grep -q "GET\s*${HEALTHCHECK_PATH}\s" "$ROUTES_FILE"; then
+  echo "ERROR: healthcheckPath $HEALTHCHECK_PATH not found in $ROUTES_FILE"
+  exit 1
+fi
+echo "✓ Healthcheck path exists in routes: $HEALTHCHECK_PATH"
+
+echo "✓ railway.toml validation passed"

--- a/test-railway-config.sh
+++ b/test-railway-config.sh
@@ -81,7 +81,8 @@ if [[ ! -f "$ROUTES_FILE" ]]; then
   exit 1
 fi
 
-if ! grep -qF "GET     ${HEALTHCHECK_PATH} " "$ROUTES_FILE"; then
+ESCAPED_PATH=$(echo "$HEALTHCHECK_PATH" | sed 's/[.[\*^$]/\\&/g')
+if ! grep -qE "^GET[[:space:]]+${ESCAPED_PATH}[[:space:]]" "$ROUTES_FILE"; then
   echo "ERROR: healthcheckPath $HEALTHCHECK_PATH not found in $ROUTES_FILE"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Adds shell script to validate `railway.toml` configuration
- Validates Dockerfile path exists
- Validates entrypoint script exists
- Validates healthcheck path matches routes configuration
- Exits with proper codes for CI integration

## Test plan

- [x] Run `./test-railway-config.sh` with valid configuration (passes)
- [x] Test with invalid Dockerfile path (fails with error)
- [x] Test with invalid healthcheck path (fails with error)
- [x] Verify exit codes (0 on success, 1 on failure)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone shell validation script; main risk is CI false-fails if `railway.toml` or route formats change, but no runtime code paths are affected.
> 
> **Overview**
> Adds `test-railway-config.sh` to *automatically validate Railway deployment configuration* in CI/local runs.
> 
> The script checks `railway.toml` exists and contains `dockerfilePath`, `startCommand`, and `healthcheckPath`, validates referenced files (Dockerfile and, when applicable, `services/api/docker-entrypoint.sh`) exist, and verifies the healthcheck route is present in `services/api/src/main/resources/routes`, failing with non-zero exit codes on mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c013068e6dab5617e463ed427f7bea05d8aec16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->